### PR TITLE
feat(orthrus): implement server-side Docker proxy listener

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -361,6 +361,88 @@ jobs:
           cosign attach sbom --sbom sbom-nightly.json "${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.resolve_digest.outputs.digest }}"
           echo "✅ SBOM attached to Docker Hub nightly image"
 
+  build-and-push-nightly-orthrus:
+    needs: sync-development-to-nightly
+    if: needs.sync-development-to-nightly.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      ORTHRUS_IMAGE_NAME: wikid82/orthrus
+      HAS_DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout nightly branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || 'nightly' }}
+          fetch-depth: 0
+
+      - name: Set lowercase image name
+        run: echo "ORTHRUS_IMAGE_NAME_LC=${ORTHRUS_IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: env.HAS_DOCKERHUB_TOKEN == 'true'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        with:
+          images: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.ORTHRUS_IMAGE_NAME_LC }}
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ env.ORTHRUS_IMAGE_NAME_LC }}
+          tags: |
+            type=raw,value=nightly
+            type=raw,value=nightly-{{date 'YYYY-MM-DD'}}
+            type=sha,prefix=nightly-,format=short
+          labels: |
+            org.opencontainers.image.title=Orthrus Agent Nightly
+            org.opencontainers.image.description=Nightly build of the Orthrus reverse-proxy agent
+
+      - name: Build and push Orthrus nightly image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: ./agent
+          file: ./agent/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=nightly-${{ github.sha }}
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.repository.pushed_at }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Record Orthrus nightly image tags
+        run: |
+          {
+            echo "## 🐕 Orthrus Nightly Image Tags"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   test-nightly-image:
     needs: build-and-push-nightly
     runs-on: ubuntu-latest

--- a/.github/workflows/orthrus-build.yml
+++ b/.github/workflows/orthrus-build.yml
@@ -3,7 +3,8 @@ name: Orthrus Agent — Build & Publish
 # Mirrors the trigger and tagging strategy from docker-build.yml so that the
 # Orthrus agent image always receives the same identifiable tags as the main
 # Charon image (e.g. feature-hecate-abc1234), enabling coordinated manual
-# testing on remote servers.
+# testing on remote servers. The push trigger has no paths filter (matching
+# docker-build.yml); paths filtering is only applied to pull_request events.
 
 "on":
   pull_request:
@@ -13,9 +14,6 @@ name: Orthrus Agent — Build & Publish
   push:
     branches: [main, development]
     tags: ['v*']
-    paths:
-      - 'agent/**'
-      - '.github/workflows/orthrus-build.yml'
   workflow_dispatch:
     inputs:
       reason:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "docker.host": "unix:///run/user/1001/docker.sock",
+  "go.goroot": "/home/jeremy/sdk/go1.26.3",
   "gopls": {
     "buildFlags": ["-tags=integration"]
   },

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,9 @@ ARG NPM_VERSION=11.11.1
 # this ARG to a specific v2.x tag when desired.
 ## Try to build the requested Caddy v2.x tag (Renovate can update this ARG).
 ## If the requested tag isn't available, fall back to a known-good v2.11.3 build.
+# renovate: datasource=go depName=https://github.com/caddyserver/caddy
 ARG CADDY_VERSION=2.11.3
+# renovate: datasource=go depName=https://github.com/caddyserver/caddy
 ARG CADDY_CANDIDATE_VERSION=2.11.3
 ARG CADDY_USE_CANDIDATE=0
 ARG CADDY_PATCH_SCENARIO=B

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,9 @@ ARG NPM_VERSION=11.11.1
 # avoid accidentally pulling a v3 major release. Renovate can still update
 # this ARG to a specific v2.x tag when desired.
 ## Try to build the requested Caddy v2.x tag (Renovate can update this ARG).
-## If the requested tag isn't available, fall back to a known-good v2.11.2 build.
-ARG CADDY_VERSION=2.11.2
-ARG CADDY_CANDIDATE_VERSION=2.11.2
+## If the requested tag isn't available, fall back to a known-good v2.11.3 build.
+ARG CADDY_VERSION=2.11.3
+ARG CADDY_CANDIDATE_VERSION=2.11.3
 ARG CADDY_USE_CANDIDATE=0
 ARG CADDY_PATCH_SCENARIO=B
 # renovate: datasource=go depName=github.com/greenpau/caddy-security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ public disclosure.
 
 ## Known Vulnerabilities
 
-Last reviewed: 2026-04-21
+Last reviewed: 2026-05-20
 
 ### [HIGH] CVE-2026-31790 · OpenSSL Vulnerability in Alpine Base Image
 
@@ -194,6 +194,91 @@ attacker-controlled URLs. Charon's application logic does not use busybox wget. 
 **Planned Remediation**
 Monitor Alpine 3.23 for a patched busybox APK. No immediate action required. Practical risk to
 Charon users is negligible since the vulnerable code path is not exercised.
+
+---
+
+### [HIGH] CVE-2026-45135 · Caddy FastCGI Unsafe Unicode Handling in splitPos
+
+| Field        | Value |
+|--------------|-------|
+| **ID**       | CVE-2026-45135 |
+| **Severity** | High · 8.1 |
+| **Status**   | Fix in Dockerfile (v2.11.3) — Pending Image Rebuild |
+
+**What**
+Caddy v2.11.2 contains unsafe Unicode handling in the FastCGI `splitPos` function. A
+network-reachable attacker (no privileges required, high attack complexity) can trigger
+potential confidentiality and integrity impact through malformed Unicode in FastCGI requests.
+
+**Who**
+
+- Discovered by: Automated scan (Trivy image scan)
+- Reported: 2026-05-20
+- Affects: Charon deployments using the FastCGI reverse proxy capability
+
+**Where**
+
+- Component: `github.com/caddyserver/caddy/v2` v2.11.2 (embedded in Charon binary via xcaddy)
+- Versions affected: Caddy < v2.11.3
+
+**When**
+
+- Discovered: 2026-05-20
+- Disclosed (if public): Public
+- Target fix: v2.11.3 (available)
+
+**How**
+Caddy is not a Go module dependency — it is built from source via xcaddy in the Dockerfile
+multi-stage build. The `CADDY_VERSION` ARG in the Dockerfile **is already pinned to 2.11.3**,
+which contains the fix. The vulnerability only affects the stale `charon:local` image built
+before this Dockerfile change. A container image rebuild applies the fix.
+
+**Planned Remediation**
+Rebuild the container image. No code changes required. The fix is already present in the
+Dockerfile (`ARG CADDY_VERSION=2.11.3`).
+
+---
+
+### [HIGH] CVE-2026-32286 · pgproto3 DoS via Negative DataRow Field Length
+
+| Field        | Value |
+|--------------|-------|
+| **ID**       | CVE-2026-32286 |
+| **Severity** | High · 7.5 |
+| **Status**   | Awaiting Upstream |
+
+**What**
+`github.com/jackc/pgproto3/v2` v2.3.3 — `DataRow.Decode` does not validate field length
+before allocation. A malicious or compromised PostgreSQL server can send a DataRow message
+with a negative field length to trigger a panic or excessive memory allocation, causing denial
+of service (CWE-400).
+
+**Who**
+
+- Discovered by: Automated scan (Trivy image scan)
+- Reported: 2026-05-20
+- Affects: Charon deployments connecting to an untrusted PostgreSQL server (non-default)
+
+**Where**
+
+- Component: `github.com/jackc/pgproto3/v2` v2.3.3 (transitive Go dependency)
+- Versions affected: pgproto3/v2 < patched version
+
+**When**
+
+- Discovered: 2026-05-20
+- Disclosed (if public): Public
+- Target fix: When upstream publishes a patched release
+
+**How**
+Exploitation requires a malicious or compromised PostgreSQL server to send a crafted DataRow
+message. Charon's default installation uses SQLite and does not connect to PostgreSQL. Users
+deploying Charon with a PostgreSQL backend (non-standard configuration) may be exposed if the
+database server is untrusted. EPSS score not yet available.
+
+**Planned Remediation**
+Monitor https://github.com/jackc/pgproto3 for a fix release. Upgrade the indirect dependency
+once a patched version is available. Pre-existing; not introduced by PR #1031.
 
 ## Patched Vulnerabilities
 

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -114,12 +114,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/oschwald/geoip2-golang/v2 v2.1.0 h1:DjnLhNJu9WHwTrmoiQFvgmyJoczhdnm7LB23UBI2Amo=
-github.com/oschwald/geoip2-golang/v2 v2.1.0/go.mod h1:qdVmcPgrTJ4q2eP9tHq/yldMTdp2VMr33uVdFbHBiBc=
 github.com/oschwald/geoip2-golang/v2 v2.2.0 h1:gdkhpnHQMiH9ymOI+zSB0QKFGH+n4TntNt7vz+TxGPY=
 github.com/oschwald/geoip2-golang/v2 v2.2.0/go.mod h1:xW4tCeQiNU1gqMD1x7zEH2CDNM3d796Ls50yxYDaX0U=
-github.com/oschwald/maxminddb-golang/v2 v2.2.0 h1:/2khmIiNvFxgfwGxitper3XBJBs5qTCPQ/H1iR9MgBw=
-github.com/oschwald/maxminddb-golang/v2 v2.2.0/go.mod h1:n/ctYVTFYQypkn5uO1CZnTmj8jdQKIVh/LX7gSaIl0w=
 github.com/oschwald/maxminddb-golang/v2 v2.3.0 h1:PnXjMGjkSQlwOBSyZ7hk6Fd75t7erkAhJNJgEhA3MQU=
 github.com/oschwald/maxminddb-golang/v2 v2.3.0/go.mod h1:NSQvgFwPxODpBTJI5+5Ns1AAucnx7ggW9PSRRifAT1s=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=

--- a/backend/internal/api/handlers/orthrus_handler.go
+++ b/backend/internal/api/handlers/orthrus_handler.go
@@ -3,21 +3,42 @@ package handlers
 import (
 	"errors"
 	"net/http"
+	"reflect"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	"github.com/Wikid82/charon/backend/internal/orthrus"
 	"github.com/Wikid82/charon/backend/internal/services"
 )
 
+// orthrusProxyStatusResolver is satisfied by *orthrus.OrthrusServer.
+type orthrusProxyStatusResolver interface {
+	GetExternalProxyStatus(agentUUID string) (orthrus.ExternalProxyStatus, bool)
+}
+
 // OrthrusHandler handles REST requests for Orthrus agent management.
 type OrthrusHandler struct {
-	svc *services.OrthrusService
+	svc           *services.OrthrusService
+	proxyResolver orthrusProxyStatusResolver
 }
 
 // NewOrthrusHandler creates an OrthrusHandler backed by the given service.
 func NewOrthrusHandler(orthrsuSvc *services.OrthrusService) *OrthrusHandler {
 	return &OrthrusHandler{svc: orthrsuSvc}
+}
+
+// SetProxyResolver wires a live OrthrusServer so that GetProxyStatus can
+// return real-time external proxy state for connected agents.
+func (h *OrthrusHandler) SetProxyResolver(r orthrusProxyStatusResolver) {
+	if r != nil {
+		rv := reflect.ValueOf(r)
+		if rv.Kind() == reflect.Ptr && rv.IsNil() {
+			h.proxyResolver = nil
+			return
+		}
+	}
+	h.proxyResolver = r
 }
 
 // RegisterRoutes wires all Orthrus management routes onto the given router group.
@@ -29,6 +50,7 @@ func (h *OrthrusHandler) RegisterRoutes(rg *gin.RouterGroup) {
 	rg.DELETE("/orthrus/agents/:uuid", h.Delete)
 	rg.POST("/orthrus/agents/:uuid/revoke", h.Revoke)
 	rg.GET("/orthrus/agents/:uuid/snippets", h.GetInstallSnippets)
+	rg.GET("/orthrus/agents/:uuid/proxy-status", h.GetProxyStatus)
 }
 
 // List returns all registered Orthrus agents.
@@ -77,10 +99,11 @@ func (h *OrthrusHandler) Get(c *gin.Context) {
 
 // patchAgentRequest is the payload for partially updating an agent.
 type patchAgentRequest struct {
-	Name             *string `json:"name"`
-	HecateTunnelUUID *string `json:"hecate_tunnel_uuid"`
-	DeviceID         *string `json:"device_id"`
-	ResolvedAddress  *string `json:"resolved_address"`
+	Name              *string `json:"name"`
+	HecateTunnelUUID  *string `json:"hecate_tunnel_uuid"`
+	DeviceID          *string `json:"device_id"`
+	ResolvedAddress   *string `json:"resolved_address"`
+	ExternalProxyPort *int    `json:"external_proxy_port"`
 }
 
 // Patch applies a partial update to an Orthrus agent.
@@ -91,12 +114,12 @@ func (h *OrthrusHandler) Patch(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	agent, err := h.svc.Patch(uuid, req.Name, req.HecateTunnelUUID, req.DeviceID, req.ResolvedAddress)
+	agent, err := h.svc.Patch(uuid, req.Name, req.HecateTunnelUUID, req.DeviceID, req.ResolvedAddress, req.ExternalProxyPort)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "agent not found"})
 		} else {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		}
 		return
 	}
@@ -149,4 +172,39 @@ func (h *OrthrusHandler) GetInstallSnippets(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, snippets)
+}
+
+// GetProxyStatus returns the runtime external Docker proxy state for an agent.
+// 404 when the agent is not found in the database. When the agent exists but
+// is not currently connected, agent_online is false and live fields are zero.
+func (h *OrthrusHandler) GetProxyStatus(c *gin.Context) {
+	uuid := c.Param("uuid")
+	agent, err := h.svc.Get(uuid)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "agent not found"})
+		return
+	}
+	resp := gin.H{
+		"agent_uuid":        agent.UUID,
+		"agent_online":      false,
+		"configured_port":   agent.ExternalProxyPort,
+		"active":            false,
+		"active_port":       0,
+		"bind_address":      "",
+		"connection_string": "",
+		"error":             "",
+	}
+	if h.proxyResolver != nil {
+		if status, ok := h.proxyResolver.GetExternalProxyStatus(uuid); ok {
+			resp["agent_online"] = true
+			resp["active"] = status.Active
+			resp["active_port"] = status.ActivePort
+			resp["bind_address"] = status.BoundAddress
+			resp["connection_string"] = status.ConnectionString
+			if status.Error != "" {
+				resp["error"] = status.Error
+			}
+		}
+	}
+	c.JSON(http.StatusOK, resp)
 }

--- a/backend/internal/api/handlers/orthrus_handler_test.go
+++ b/backend/internal/api/handlers/orthrus_handler_test.go
@@ -713,3 +713,112 @@ func TestOrthrusHandler_GetProxyStatus_Connected(t *testing.T) {
 	assert.Equal(t, "0.0.0.0:2375", resp["bind_address"])
 	assert.Equal(t, "tcp://charon:2375", resp["connection_string"])
 }
+
+// TestOrthrusHandler_SetProxyResolver_TypedNilClearsResolver verifies that
+// passing a typed nil pointer (non-nil interface wrapping nil pointer) causes
+// SetProxyResolver to clear the stored resolver via the reflect.IsNil branch.
+func TestOrthrusHandler_SetProxyResolver_TypedNilClearsResolver(t *testing.T) {
+	h, _ := newOrthrusTestSetup(t)
+
+	// Wire a valid resolver first.
+	h.SetProxyResolver(&mockProxyResolver{ok: true})
+
+	// Pass a typed nil *mockProxyResolver — the interface value is non-nil but
+	// rv.IsNil() returns true, exercising the h.proxyResolver = nil / return path.
+	var nilResolver *mockProxyResolver
+	h.SetProxyResolver(nilResolver)
+
+	// Confirm the resolver was cleared: provision an agent and verify
+	// GetProxyStatus returns agent_online=false (no resolver active).
+	wProv := httptest.NewRecorder()
+	cProv, _ := gin.CreateTestContext(wProv)
+	cProv.Request = httptest.NewRequest(http.MethodPost, "/management/orthrus/agents",
+		bytes.NewBufferString(`{"name":"typed-nil-agent"}`))
+	cProv.Request.Header.Set("Content-Type", "application/json")
+	h.Provision(cProv)
+	require.Equal(t, http.StatusCreated, wProv.Code)
+	var provisioned map[string]any
+	require.NoError(t, json.Unmarshal(wProv.Body.Bytes(), &provisioned))
+	agentUUID := provisioned["agent"].(map[string]any)["uuid"].(string)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/management/orthrus/agents/"+agentUUID+"/proxy-status", http.NoBody)
+	c.Params = gin.Params{{Key: "uuid", Value: agentUUID}}
+	h.GetProxyStatus(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["agent_online"])
+}
+
+// TestOrthrusHandler_Patch_MalformedJSON verifies that sending a body that
+// cannot be parsed as JSON triggers the ShouldBindJSON error path → 400.
+func TestOrthrusHandler_Patch_MalformedJSON(t *testing.T) {
+	h, _ := newOrthrusTestSetup(t)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/management/orthrus/agents/any-uuid",
+		bytes.NewBufferString(`{not valid json`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "uuid", Value: "any-uuid"}}
+
+	h.Patch(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestOrthrusHandler_GetProxyStatus_AgentNotFound verifies that requesting
+// proxy status for a non-existent agent UUID returns 404.
+func TestOrthrusHandler_GetProxyStatus_AgentNotFound(t *testing.T) {
+	h, _ := newOrthrusTestSetup(t)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/management/orthrus/agents/does-not-exist/proxy-status", http.NoBody)
+	c.Params = gin.Params{{Key: "uuid", Value: "does-not-exist"}}
+
+	h.GetProxyStatus(c)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestOrthrusHandler_GetProxyStatus_Connected_WithError verifies that when the
+// resolver returns a status with a non-empty Error field, the error is included
+// in the response — covering the if status.Error != "" branch.
+func TestOrthrusHandler_GetProxyStatus_Connected_WithError(t *testing.T) {
+	h, _ := newOrthrusTestSetup(t)
+
+	wProv := httptest.NewRecorder()
+	cProv, _ := gin.CreateTestContext(wProv)
+	cProv.Request = httptest.NewRequest(http.MethodPost, "/management/orthrus/agents",
+		bytes.NewBufferString(`{"name":"error-agent"}`))
+	cProv.Request.Header.Set("Content-Type", "application/json")
+	h.Provision(cProv)
+	require.Equal(t, http.StatusCreated, wProv.Code)
+	var provisioned map[string]any
+	require.NoError(t, json.Unmarshal(wProv.Body.Bytes(), &provisioned))
+	agentUUID := provisioned["agent"].(map[string]any)["uuid"].(string)
+
+	errStatus := orthrus.ExternalProxyStatus{
+		ConfiguredPort: 2375,
+		Active:         false,
+		Error:          "bind failed: address already in use",
+	}
+	h.SetProxyResolver(&mockProxyResolver{status: errStatus, ok: true})
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/management/orthrus/agents/"+agentUUID+"/proxy-status", http.NoBody)
+	c.Params = gin.Params{{Key: "uuid", Value: agentUUID}}
+	h.GetProxyStatus(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["agent_online"])
+	assert.Equal(t, false, resp["active"])
+	assert.Equal(t, "bind failed: address already in use", resp["error"])
+}

--- a/backend/internal/api/handlers/orthrus_handler_test.go
+++ b/backend/internal/api/handlers/orthrus_handler_test.go
@@ -495,6 +495,7 @@ func TestOrthrusHandler_RegisterRoutes(t *testing.T) {
 	assert.True(t, paths["DELETE /management/orthrus/agents/:uuid"])
 	assert.True(t, paths["POST /management/orthrus/agents/:uuid/revoke"])
 	assert.True(t, paths["GET /management/orthrus/agents/:uuid/snippets"])
+	assert.True(t, paths["GET /management/orthrus/agents/:uuid/proxy-status"])
 }
 
 func TestOrthrusHandler_List_InternalError(t *testing.T) {
@@ -551,4 +552,164 @@ func TestOrthrusHandler_Revoke_InternalError(t *testing.T) {
 	c.Params = gin.Params{{Key: "uuid", Value: "uuid-x"}}
 	h.Revoke(c)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// mockProxyResolver satisfies orthrusProxyStatusResolver for testing.
+type mockProxyResolver struct {
+	status orthrus.ExternalProxyStatus
+	ok     bool
+}
+
+func (m *mockProxyResolver) GetExternalProxyStatus(_ string) (orthrus.ExternalProxyStatus, bool) {
+	return m.status, m.ok
+}
+
+func TestOrthrusHandler_PatchAgent_ExternalProxyPort_Valid(t *testing.T) {
+	h, _ := newOrthrusTestSetup(t)
+
+	wProv := httptest.NewRecorder()
+	cProv, _ := gin.CreateTestContext(wProv)
+	cProv.Request = httptest.NewRequest(http.MethodPost, "/management/orthrus/agents",
+		bytes.NewBufferString(`{"name":"port-agent"}`))
+	cProv.Request.Header.Set("Content-Type", "application/json")
+	h.Provision(cProv)
+	require.Equal(t, http.StatusCreated, wProv.Code)
+	var provisioned map[string]any
+	require.NoError(t, json.Unmarshal(wProv.Body.Bytes(), &provisioned))
+	agentUUID := provisioned["agent"].(map[string]any)["uuid"].(string)
+
+	body, _ := json.Marshal(map[string]int{"external_proxy_port": 2375})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/management/orthrus/agents/"+agentUUID,
+		bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "uuid", Value: agentUUID}}
+	h.Patch(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp models.OrthrusAgent
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2375, resp.ExternalProxyPort)
+}
+
+func TestOrthrusHandler_PatchAgent_ExternalProxyPort_Invalid(t *testing.T) {
+	h, _ := newOrthrusTestSetup(t)
+
+	wProv := httptest.NewRecorder()
+	cProv, _ := gin.CreateTestContext(wProv)
+	cProv.Request = httptest.NewRequest(http.MethodPost, "/management/orthrus/agents",
+		bytes.NewBufferString(`{"name":"port-bad-agent"}`))
+	cProv.Request.Header.Set("Content-Type", "application/json")
+	h.Provision(cProv)
+	require.Equal(t, http.StatusCreated, wProv.Code)
+	var provisioned map[string]any
+	require.NoError(t, json.Unmarshal(wProv.Body.Bytes(), &provisioned))
+	agentUUID := provisioned["agent"].(map[string]any)["uuid"].(string)
+
+	body, _ := json.Marshal(map[string]int{"external_proxy_port": 80})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/management/orthrus/agents/"+agentUUID,
+		bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "uuid", Value: agentUUID}}
+	h.Patch(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestOrthrusHandler_GetProxyStatus_NilResolver(t *testing.T) {
+	h, _ := newOrthrusTestSetup(t)
+
+	wProv := httptest.NewRecorder()
+	cProv, _ := gin.CreateTestContext(wProv)
+	cProv.Request = httptest.NewRequest(http.MethodPost, "/management/orthrus/agents",
+		bytes.NewBufferString(`{"name":"nil-resolver-agent"}`))
+	cProv.Request.Header.Set("Content-Type", "application/json")
+	h.Provision(cProv)
+	require.Equal(t, http.StatusCreated, wProv.Code)
+	var provisioned map[string]any
+	require.NoError(t, json.Unmarshal(wProv.Body.Bytes(), &provisioned))
+	agentUUID := provisioned["agent"].(map[string]any)["uuid"].(string)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/management/orthrus/agents/"+agentUUID+"/proxy-status", http.NoBody)
+	c.Params = gin.Params{{Key: "uuid", Value: agentUUID}}
+	h.GetProxyStatus(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["agent_online"])
+	assert.Equal(t, false, resp["active"])
+}
+
+func TestOrthrusHandler_GetProxyStatus_NotConnected(t *testing.T) {
+	h, _ := newOrthrusTestSetup(t)
+
+	wProv := httptest.NewRecorder()
+	cProv, _ := gin.CreateTestContext(wProv)
+	cProv.Request = httptest.NewRequest(http.MethodPost, "/management/orthrus/agents",
+		bytes.NewBufferString(`{"name":"not-connected-agent"}`))
+	cProv.Request.Header.Set("Content-Type", "application/json")
+	h.Provision(cProv)
+	require.Equal(t, http.StatusCreated, wProv.Code)
+	var provisioned map[string]any
+	require.NoError(t, json.Unmarshal(wProv.Body.Bytes(), &provisioned))
+	agentUUID := provisioned["agent"].(map[string]any)["uuid"].(string)
+
+	h.SetProxyResolver(&mockProxyResolver{ok: false})
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/management/orthrus/agents/"+agentUUID+"/proxy-status", http.NoBody)
+	c.Params = gin.Params{{Key: "uuid", Value: agentUUID}}
+	h.GetProxyStatus(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["agent_online"])
+	assert.Equal(t, false, resp["active"])
+}
+
+func TestOrthrusHandler_GetProxyStatus_Connected(t *testing.T) {
+	h, _ := newOrthrusTestSetup(t)
+
+	wProv := httptest.NewRecorder()
+	cProv, _ := gin.CreateTestContext(wProv)
+	cProv.Request = httptest.NewRequest(http.MethodPost, "/management/orthrus/agents",
+		bytes.NewBufferString(`{"name":"connected-agent"}`))
+	cProv.Request.Header.Set("Content-Type", "application/json")
+	h.Provision(cProv)
+	require.Equal(t, http.StatusCreated, wProv.Code)
+	var provisioned map[string]any
+	require.NoError(t, json.Unmarshal(wProv.Body.Bytes(), &provisioned))
+	agentUUID := provisioned["agent"].(map[string]any)["uuid"].(string)
+
+	liveStatus := orthrus.ExternalProxyStatus{
+		ConfiguredPort:   2375,
+		ActivePort:       2375,
+		BoundAddress:     "0.0.0.0:2375",
+		ConnectionString: "tcp://charon:2375",
+		Active:           true,
+	}
+	h.SetProxyResolver(&mockProxyResolver{status: liveStatus, ok: true})
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/management/orthrus/agents/"+agentUUID+"/proxy-status", http.NoBody)
+	c.Params = gin.Params{{Key: "uuid", Value: agentUUID}}
+	h.GetProxyStatus(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["agent_online"])
+	assert.Equal(t, true, resp["active"])
+	assert.Equal(t, float64(2375), resp["active_port"])
+	assert.Equal(t, "0.0.0.0:2375", resp["bind_address"])
+	assert.Equal(t, "tcp://charon:2375", resp["connection_string"])
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -487,6 +487,10 @@ func RegisterWithDeps(ctx context.Context, router *gin.Engine, db *gorm.DB, cfg 
 				orthrusHandler := handlers.NewOrthrusHandler(orthrsuSvc)
 				orthrusHandler.RegisterRoutes(management)
 
+				if orthrusServer != nil {
+					orthrusHandler.SetProxyResolver(orthrusServer)
+				}
+
 				hecateWSHandler := handlers.NewHecateWSHandler(hecateSvc, wsTracker)
 				management.GET("/ws/hecate/logs/:uuid", hecateWSHandler.StreamLogs)
 

--- a/backend/internal/models/orthrus_agent.go
+++ b/backend/internal/models/orthrus_agent.go
@@ -43,6 +43,10 @@ type OrthrusAgent struct {
 	// set by Charon at assignment time, used as upstream host in Remote Servers.
 	ResolvedAddress *string `json:"resolved_address,omitempty"`
 
+	// ExternalProxyPort is the TCP port bound on 0.0.0.0 for inter-container Docker API access.
+	// 0 = disabled. Valid values: 1024–65535.
+	ExternalProxyPort int `json:"external_proxy_port" gorm:"default:0"`
+
 	LastHeartbeat *time.Time `json:"last_heartbeat,omitempty"`
 	LastSeen      *time.Time `json:"last_seen,omitempty"`
 	CreatedAt     time.Time  `json:"created_at"`

--- a/backend/internal/orthrus/server.go
+++ b/backend/internal/orthrus/server.go
@@ -91,12 +91,20 @@ func (s *OrthrusServer) HandleWebSocket(c *gin.Context) {
 		return
 	}
 
-	s.sessions.Store(agent.UUID, session)
-
 	if err := session.StartDockerProxy(); err != nil {
 		logger.Log().WithField("uuid", util.SanitizeForLog(agent.UUID)).
 			WithError(err).Warn("orthrus: failed to start docker proxy listener")
 	}
+
+	if agent.ExternalProxyPort > 0 {
+		if err := session.StartExternalProxy(agent.ExternalProxyPort); err != nil {
+			logger.Log().WithField("uuid", util.SanitizeForLog(agent.UUID)).
+				WithField("port", agent.ExternalProxyPort).
+				WithError(err).Warn("orthrus: failed to start external proxy")
+		}
+	}
+
+	s.sessions.Store(agent.UUID, session)
 
 	now := time.Now()
 	if err := s.db.Model(agent).Updates(map[string]interface{}{
@@ -116,6 +124,17 @@ func (s *OrthrusServer) HandleWebSocket(c *gin.Context) {
 		defer s.wg.Done()
 		s.watchHeartbeat(agent.UUID, session)
 	}()
+}
+
+// GetExternalProxyStatus returns the external proxy status for a connected agent.
+// Returns (ExternalProxyStatus{}, false) when no active session exists.
+func (s *OrthrusServer) GetExternalProxyStatus(agentUUID string) (ExternalProxyStatus, bool) {
+	raw, ok := s.sessions.Load(agentUUID)
+	if !ok {
+		return ExternalProxyStatus{}, false
+	}
+	sess := raw.(*AgentSession)
+	return sess.GetExternalProxyStatus(), true
 }
 
 // GetProxyAddr returns the proxy listener address for a connected agent.

--- a/backend/internal/orthrus/server.go
+++ b/backend/internal/orthrus/server.go
@@ -93,6 +93,11 @@ func (s *OrthrusServer) HandleWebSocket(c *gin.Context) {
 
 	s.sessions.Store(agent.UUID, session)
 
+	if err := session.StartDockerProxy(); err != nil {
+		logger.Log().WithField("uuid", util.SanitizeForLog(agent.UUID)).
+			WithError(err).Warn("orthrus: failed to start docker proxy listener")
+	}
+
 	now := time.Now()
 	if err := s.db.Model(agent).Updates(map[string]interface{}{
 		"status":    models.OrthrusStatusOnline,
@@ -163,6 +168,7 @@ func (s *OrthrusServer) watchHeartbeat(agentUUID string, sess *AgentSession) {
 			return
 		case <-ticker.C:
 			if !sess.IsAlive() {
+				_ = sess.Close() // stops runProxyListener goroutine; idempotent
 				s.markOffline(agentUUID)
 				s.sessions.Delete(agentUUID)
 				return

--- a/backend/internal/orthrus/server_coverage_test.go
+++ b/backend/internal/orthrus/server_coverage_test.go
@@ -1,6 +1,7 @@
 package orthrus
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -277,4 +278,93 @@ func TestOrthrusServer_FindAgentByToken_DBError_ReturnsError(t *testing.T) {
 
 	_, err = srv.findAgentByToken("anytoken")
 	assert.Error(t, err)
+}
+
+// TestOrthrusServer_HandleWebSocket_UpgradeFailure covers server.go:82-85 —
+// the error-log path when wsUpgrader.Upgrade rejects a non-WebSocket request.
+func TestOrthrusServer_HandleWebSocket_UpgradeFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := setupServerTestDB(t)
+	srv, err := NewOrthrusServer(db, setupTestCA(t))
+	require.NoError(t, err)
+
+	token := "ch_orthrus_upgerr01" //nolint:gosec // G101: test credential
+	hash, err := bcrypt.GenerateFromPassword([]byte(token), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	agent := &models.OrthrusAgent{
+		UUID:        "upgerr-uuid",
+		Name:        "upgerr-agent",
+		AuthKeyHash: string(hash),
+		Status:      models.OrthrusStatusPending,
+	}
+	require.NoError(t, db.Create(agent).Error)
+
+	// Plain HTTP GET with valid auth — NOT a WebSocket upgrade.
+	// wsUpgrader.Upgrade writes 400 Bad Request and returns an error.
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodGet, "/ws", http.NoBody)
+	req.Header.Set("Authorization", "Bearer "+token)
+	c.Request = req
+
+	// Should not panic; handler logs the error and returns.
+	srv.HandleWebSocket(c)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestOrthrusServer_HandleWebSocket_ExternalProxyFails covers server.go:100-104 —
+// the warning-log path when StartExternalProxy fails on an occupied port.
+func TestOrthrusServer_HandleWebSocket_ExternalProxyFails(t *testing.T) {
+	// Occupy a port so StartExternalProxy cannot bind it.
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	blockedPort := blocker.Addr().(*net.TCPAddr).Port
+	defer blocker.Close() //nolint:errcheck
+
+	db := setupServerTestDB(t)
+	srv, err := NewOrthrusServer(db, setupTestCA(t))
+	require.NoError(t, err)
+	srv.heartbeatTimeout = 200 * time.Millisecond
+
+	token := "ch_orthrus_extfail02" //nolint:gosec // G101: test credential
+	hash, err := bcrypt.GenerateFromPassword([]byte(token), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	agent := &models.OrthrusAgent{
+		UUID:              "extfail-uuid",
+		Name:              "extfail-agent",
+		AuthKeyHash:       string(hash),
+		Status:            models.OrthrusStatusPending,
+		ExternalProxyPort: blockedPort,
+	}
+	require.NoError(t, db.Create(agent).Error)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/ws", srv.HandleWebSocket)
+	ts := httptest.NewServer(router)
+	t.Cleanup(srv.Stop)
+	t.Cleanup(ts.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+	header := http.Header{"Authorization": []string{"Bearer " + token}}
+	conn, dialResp, err := gorillaws.DefaultDialer.Dial(wsURL, header)
+	require.NoError(t, err)
+	if dialResp != nil {
+		_ = dialResp.Body.Close()
+	}
+	defer func() { _ = conn.Close() }()
+
+	// sessions.Store is called after StartExternalProxy, so once the session is
+	// present the proxy attempt (and its failure) has already completed.
+	assert.Eventually(t, func() bool {
+		_, ok := srv.GetSession("extfail-uuid")
+		return ok
+	}, 2*time.Second, 20*time.Millisecond, "session should be stored after WS connect")
+
+	status, ok := srv.GetExternalProxyStatus("extfail-uuid")
+	require.True(t, ok)
+	assert.False(t, status.Active)
+	assert.NotEmpty(t, status.Error)
 }

--- a/backend/internal/orthrus/server_external_proxy_test.go
+++ b/backend/internal/orthrus/server_external_proxy_test.go
@@ -1,0 +1,112 @@
+package orthrus
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	gorillaws "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/Wikid82/charon/backend/internal/models"
+)
+
+// U-SRV-01: HandleWebSocket with ExternalProxyPort > 0 starts the external proxy;
+// GetExternalProxyStatus returns Active=true with the configured port.
+func TestOrthrusServer_HandleWebSocket_StartsExternalProxy(t *testing.T) {
+	db := setupServerTestDB(t)
+	srv, err := NewOrthrusServer(db, setupTestCA(t))
+	require.NoError(t, err)
+	srv.heartbeatTimeout = 50 * time.Millisecond
+
+	port := findFreePort(t)
+
+	token := "ch_orthrus_ext_srv01" //nolint:gosec // G101: test credential
+	hash, err := bcrypt.GenerateFromPassword([]byte(token), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	agent := &models.OrthrusAgent{
+		UUID:              "ext-srv01-uuid",
+		Name:              "ext-srv01-agent",
+		AuthKeyHash:       string(hash),
+		Status:            models.OrthrusStatusPending,
+		ExternalProxyPort: port,
+	}
+	require.NoError(t, db.Create(agent).Error)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/ws", srv.HandleWebSocket)
+
+	ts := httptest.NewServer(router)
+	t.Cleanup(srv.Stop)
+	t.Cleanup(ts.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+	header := http.Header{"Authorization": []string{"Bearer " + token}}
+
+	conn, dialResp, err := gorillaws.DefaultDialer.Dial(wsURL, header)
+	require.NoError(t, err)
+	if dialResp != nil {
+		_ = dialResp.Body.Close()
+	}
+	defer func() { _ = conn.Close() }()
+
+	assert.Eventually(t, func() bool {
+		status, ok := srv.GetExternalProxyStatus("ext-srv01-uuid")
+		return ok && status.Active
+	}, 2*time.Second, 20*time.Millisecond, "external proxy should be active after WS connect")
+
+	status, ok := srv.GetExternalProxyStatus("ext-srv01-uuid")
+	require.True(t, ok)
+	assert.Equal(t, port, status.ConfiguredPort)
+	assert.Equal(t, port, status.ActivePort)
+}
+
+// U-SRV-02: DisconnectAgent with active external proxy closes the http.Server;
+// TCP dial to the external port is refused after disconnect.
+func TestOrthrusServer_DisconnectAgent_ClosesExternalProxy(t *testing.T) {
+	db := setupServerTestDB(t)
+	srv, err := NewOrthrusServer(db, setupTestCA(t))
+	require.NoError(t, err)
+	t.Cleanup(srv.Stop)
+
+	serverConn, wsCleanup := testWSPair(t)
+	defer wsCleanup()
+
+	sess, err := NewAgentSession("ext-srv02-uuid", "ext-srv02-agent", serverConn)
+	require.NoError(t, err)
+	require.NoError(t, sess.StartDockerProxy())
+
+	port := findFreePort(t)
+	require.NoError(t, sess.StartExternalProxy(port))
+
+	assert.Eventually(t, func() bool {
+		return sess.GetExternalProxyStatus().Active
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Verify external port is reachable before disconnect.
+	c, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 500*time.Millisecond)
+	require.NoError(t, err)
+	_ = c.Close()
+
+	agent := &models.OrthrusAgent{
+		UUID:   "ext-srv02-uuid",
+		Name:   "ext-srv02-agent",
+		Status: models.OrthrusStatusOnline,
+	}
+	require.NoError(t, db.Create(agent).Error)
+
+	srv.sessions.Store("ext-srv02-uuid", sess)
+	require.NoError(t, srv.DisconnectAgent("ext-srv02-uuid"))
+
+	_, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 500*time.Millisecond)
+	assert.Error(t, dialErr, "external proxy port should be closed after DisconnectAgent")
+}

--- a/backend/internal/orthrus/server_proxy_test.go
+++ b/backend/internal/orthrus/server_proxy_test.go
@@ -1,0 +1,114 @@
+package orthrus
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	gorillaws "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/Wikid82/charon/backend/internal/models"
+)
+
+// S1: Full WS handshake wires proxy; GetProxyAddr returns non-empty address.
+func TestOrthrusServer_HandleWebSocket_StartsDockerProxy(t *testing.T) {
+	db := setupServerTestDB(t)
+	srv, err := NewOrthrusServer(db, setupTestCA(t))
+	require.NoError(t, err)
+	srv.heartbeatTimeout = 50 * time.Millisecond
+
+	token := "ch_orthrus_proxy_s1" //nolint:gosec // G101: test credential
+	hash, err := bcrypt.GenerateFromPassword([]byte(token), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	agent := &models.OrthrusAgent{
+		UUID:        "proxy-s1-uuid",
+		Name:        "proxy-s1-agent",
+		AuthKeyHash: string(hash),
+		Status:      models.OrthrusStatusPending,
+	}
+	require.NoError(t, db.Create(agent).Error)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/ws", srv.HandleWebSocket)
+
+	ts := httptest.NewServer(router)
+	t.Cleanup(srv.Stop) // runs 2nd — must run before DB cleanup
+	t.Cleanup(ts.Close) // runs 1st — drains HTTP handlers so wg.Add races are gone
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+	header := http.Header{"Authorization": []string{"Bearer " + token}}
+
+	conn, dialResp, err := gorillaws.DefaultDialer.Dial(wsURL, header)
+	require.NoError(t, err)
+	if dialResp != nil {
+		_ = dialResp.Body.Close()
+	}
+	defer func() { _ = conn.Close() }()
+
+	assert.Eventually(t, func() bool {
+		addr, ok := srv.GetProxyAddr("proxy-s1-uuid")
+		return ok && addr != ""
+	}, 2*time.Second, 20*time.Millisecond, "proxy addr should be set after WS upgrade")
+}
+
+// S2: watchHeartbeat closes session; proxy listener stops accepting connections.
+func TestOrthrusServer_WatchHeartbeat_ClosesProxyListener(t *testing.T) {
+	db := setupServerTestDB(t)
+	srv, err := NewOrthrusServer(db, setupTestCA(t))
+	require.NoError(t, err)
+	t.Cleanup(srv.Stop)
+	srv.heartbeatTimeout = 40 * time.Millisecond
+
+	serverConn, done := testWSPair(t)
+	defer done()
+
+	sess, err := NewAgentSession("proxy-s2-uuid", "proxy-s2-agent", serverConn)
+	require.NoError(t, err)
+
+	require.NoError(t, sess.StartDockerProxy())
+	proxyAddr := sess.GetProxyAddr()
+	require.NotEmpty(t, proxyAddr)
+
+	// Verify proxy is reachable before watchHeartbeat runs.
+	c, err := net.DialTimeout("tcp", proxyAddr, 500*time.Millisecond)
+	require.NoError(t, err)
+	_ = c.Close()
+
+	agent := &models.OrthrusAgent{
+		UUID:   "proxy-s2-uuid",
+		Name:   "proxy-s2-agent",
+		Status: models.OrthrusStatusOnline,
+	}
+	require.NoError(t, db.Create(agent).Error)
+
+	// Kill yamux session directly (same package access) without closing listener.
+	// watchHeartbeat calls sess.Close() when IsAlive() returns false.
+	require.NoError(t, sess.session.Close())
+
+	srv.sessions.Store("proxy-s2-uuid", sess)
+
+	finished := make(chan struct{})
+	go func() {
+		srv.watchHeartbeat("proxy-s2-uuid", sess)
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(600 * time.Millisecond):
+		t.Fatal("watchHeartbeat did not exit within deadline")
+	}
+
+	// Proxy listener must be closed now.
+	_, dialErr := net.DialTimeout("tcp", proxyAddr, 500*time.Millisecond)
+	assert.Error(t, dialErr, "proxy listener should be closed after watchHeartbeat")
+}

--- a/backend/internal/orthrus/session.go
+++ b/backend/internal/orthrus/session.go
@@ -2,15 +2,21 @@ package orthrus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"sync"
 	"time"
 
+	"github.com/Wikid82/charon/backend/internal/logger"
 	"github.com/gorilla/websocket"
 	"github.com/hashicorp/yamux"
 )
+
+// streamTypeDocker identifies Docker socket proxy streams opened toward the agent.
+// Must match the constant in the Orthrus agent (agent/leash/leash.go).
+const streamTypeDocker = byte(0x01)
 
 // wsNetConn adapts a gorilla WebSocket connection to the net.Conn interface
 // so that yamux can use it as a byte-stream transport.
@@ -82,14 +88,15 @@ func (c *wsNetConn) SetWriteDeadline(t time.Time) error {
 }
 
 // AgentSession represents a single connected Orthrus agent's active WebSocket
-// and Yamux session. Full proxy stream forwarding is implemented in PR 5.
+// and Yamux session.
 type AgentSession struct {
 	agentUUID string
 	agentName string
 	conn      *websocket.Conn
 	session   *yamux.Session
 	cancel    context.CancelFunc
-	proxyPort int // allocated in PR 5; 0 means no proxy listener yet
+	proxyPort int          // ephemeral port; 0 until StartDockerProxy succeeds
+	listener  net.Listener // nil until StartDockerProxy succeeds; set atomically with proxyPort
 	mu        sync.Mutex
 }
 
@@ -114,12 +121,107 @@ func NewAgentSession(agentUUID, agentName string, conn *websocket.Conn) (*AgentS
 	}, nil
 }
 
-// Close terminates the Yamux session and the underlying WebSocket connection.
-// Yamux closes the underlying net.Conn (wsNetConn) when the session is closed,
-// which in turn closes the WebSocket connection; no second close is needed.
+// StartDockerProxy allocates an ephemeral loopback TCP listener and starts
+// accepting connections. Each accepted connection is tunnelled to the agent's
+// Docker socket via a new yamux stream of type streamTypeDocker (0x01).
+// Returns an error if the OS cannot allocate a port, if the proxy is already
+// running for this session (idempotency guard), or if the session is closed.
+func (s *AgentSession) StartDockerProxy() error {
+	s.mu.Lock()
+	if s.listener != nil {
+		s.mu.Unlock()
+		return fmt.Errorf("orthrus: docker proxy already started for session %s", s.agentUUID)
+	}
+	if s.session.IsClosed() {
+		s.mu.Unlock()
+		return fmt.Errorf("orthrus: cannot start proxy on closed session %s", s.agentUUID)
+	}
+	s.mu.Unlock()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("orthrus: allocate proxy listener: %w", err)
+	}
+
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	s.mu.Lock()
+	if s.listener != nil { // re-check after net.Listen (double-check pattern)
+		_ = ln.Close()
+		s.mu.Unlock()
+		return fmt.Errorf("orthrus: docker proxy already started for session %s", s.agentUUID)
+	}
+	s.listener = ln
+	s.proxyPort = port
+	s.mu.Unlock()
+
+	go s.runProxyListener(ln)
+	return nil
+}
+
+// runProxyListener accepts TCP connections from local Docker clients and
+// dispatches each to proxyConn. Exits when ln is closed (normal shutdown
+// via Close).
+func (s *AgentSession) runProxyListener(ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return // normal shutdown
+			}
+			logger.Log().WithField("uuid", s.agentUUID).WithError(err).Warn("orthrus: proxy listener accept error")
+			return
+		}
+		go s.proxyConn(conn)
+	}
+}
+
+// proxyConn opens a yamux stream, writes the Docker stream-type byte,
+// then bidirectionally copies until either side closes.
+func (s *AgentSession) proxyConn(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+
+	stream, err := s.session.Open()
+	if err != nil {
+		// yamux session already closed; expected on disconnect.
+		logger.Log().WithField("uuid", s.agentUUID).WithError(err).Debug("orthrus: open yamux stream failed")
+		return
+	}
+	defer func() { _ = stream.Close() }()
+
+	if _, err := stream.Write([]byte{streamTypeDocker}); err != nil {
+		logger.Log().WithField("uuid", s.agentUUID).WithError(err).Warn("orthrus: write stream type byte failed")
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defer func() { _ = stream.Close() }()
+		io.Copy(stream, conn) //nolint:errcheck
+	}()
+	go func() {
+		defer wg.Done()
+		defer func() { _ = conn.Close() }()
+		io.Copy(conn, stream) //nolint:errcheck
+	}()
+	wg.Wait()
+}
+
+// Close terminates the proxy listener, cancels the context, and closes the
+// Yamux session (which also closes the underlying WebSocket via wsNetConn).
 func (s *AgentSession) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if s.listener != nil {
+		_ = s.listener.Close()
+		s.listener = nil
+		// proxyPort is intentionally left non-zero for diagnostic purposes.
+		// GetProxyAddr will not be called on a closed session: the session is
+		// removed from the sessions map before any caller can observe it.
+	}
 
 	s.cancel()
 	return s.session.Close()

--- a/backend/internal/orthrus/session.go
+++ b/backend/internal/orthrus/session.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"sync"
 	"time"
 
@@ -87,17 +90,32 @@ func (c *wsNetConn) SetWriteDeadline(t time.Time) error {
 	return c.conn.SetWriteDeadline(t)
 }
 
+// ExternalProxyStatus describes the runtime state of the external Docker proxy
+// bound on 0.0.0.0 for this agent session.
+type ExternalProxyStatus struct {
+	ConfiguredPort   int    `json:"configured_port"`             // port passed to StartExternalProxy
+	ActivePort       int    `json:"active_port"`                 // actual bound port (0 if not active)
+	BoundAddress     string `json:"bind_address"`                // e.g. "0.0.0.0:9999"
+	ConnectionString string `json:"connection_string,omitempty"` // e.g. "tcp://charon:9999"
+	Active           bool   `json:"active"`
+	Error            string `json:"error,omitempty"` // last start error, if any
+}
+
 // AgentSession represents a single connected Orthrus agent's active WebSocket
 // and Yamux session.
 type AgentSession struct {
-	agentUUID string
-	agentName string
-	conn      *websocket.Conn
-	session   *yamux.Session
-	cancel    context.CancelFunc
-	proxyPort int          // ephemeral port; 0 until StartDockerProxy succeeds
-	listener  net.Listener // nil until StartDockerProxy succeeds; set atomically with proxyPort
-	mu        sync.Mutex
+	agentUUID    string
+	agentName    string
+	conn         *websocket.Conn
+	session      *yamux.Session
+	cancel       context.CancelFunc
+	proxyPort    int          // ephemeral port; 0 until StartDockerProxy succeeds
+	listener     net.Listener // nil until StartDockerProxy succeeds; set atomically with proxyPort
+	extServer    *http.Server // nil until StartExternalProxy succeeds
+	extListener  net.Listener // nil until StartExternalProxy succeeds
+	extProxyPort int          // port passed to StartExternalProxy; 0 if never started
+	extErr       error        // last error from StartExternalProxy
+	mu           sync.Mutex
 }
 
 // NewAgentSession wraps the WebSocket connection in a Yamux server session.
@@ -151,6 +169,11 @@ func (s *AgentSession) StartDockerProxy() error {
 		s.mu.Unlock()
 		return fmt.Errorf("orthrus: docker proxy already started for session %s", s.agentUUID)
 	}
+	if s.session.IsClosed() {
+		_ = ln.Close()
+		s.mu.Unlock()
+		return fmt.Errorf("orthrus: cannot start proxy on closed session %s", s.agentUUID)
+	}
 	s.listener = ln
 	s.proxyPort = port
 	s.mu.Unlock()
@@ -163,15 +186,28 @@ func (s *AgentSession) StartDockerProxy() error {
 // dispatches each to proxyConn. Exits when ln is closed (normal shutdown
 // via Close).
 func (s *AgentSession) runProxyListener(ln net.Listener) {
+	const maxTransientRetries = 5
+	var transientRetries int
+
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
 			if errors.Is(err, net.ErrClosed) {
 				return // normal shutdown
 			}
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				transientRetries++
+				if transientRetries <= maxTransientRetries {
+					logger.Log().WithField("uuid", s.agentUUID).WithError(err).Warn("orthrus: proxy listener transient error, retrying")
+					time.Sleep(time.Duration(transientRetries*100) * time.Millisecond)
+					continue
+				}
+			}
 			logger.Log().WithField("uuid", s.agentUUID).WithError(err).Warn("orthrus: proxy listener accept error")
 			return
 		}
+		transientRetries = 0 // reset on successful accept
 		go s.proxyConn(conn)
 	}
 }
@@ -199,14 +235,121 @@ func (s *AgentSession) proxyConn(conn net.Conn) {
 	go func() {
 		defer wg.Done()
 		defer func() { _ = stream.Close() }()
-		io.Copy(stream, conn) //nolint:errcheck
+		io.Copy(stream, conn) //nolint:errcheck,gosec
 	}()
 	go func() {
 		defer wg.Done()
 		defer func() { _ = conn.Close() }()
-		io.Copy(conn, stream) //nolint:errcheck
+		io.Copy(conn, stream) //nolint:errcheck,gosec
 	}()
 	wg.Wait()
+}
+
+// StartExternalProxy binds an HTTP listener on 0.0.0.0:port that reverse-proxies
+// Docker API requests through the existing loopback proxy to the agent's Docker socket.
+// Requests are filtered by Muzzle to the read-only allowlist.
+// A port of 0 is a no-op (returns nil). Returns an error if the loopback proxy is
+// not yet running, if an external proxy is already active, if the session is closed,
+// or if the OS cannot bind the port.
+func (s *AgentSession) StartExternalProxy(port int) error {
+	if port == 0 {
+		return nil
+	}
+
+	s.mu.Lock()
+	if s.proxyPort == 0 {
+		s.mu.Unlock()
+		return errors.New("orthrus: loopback proxy not started")
+	}
+	if s.extListener != nil {
+		s.mu.Unlock()
+		return errors.New("orthrus: external proxy already started")
+	}
+	if s.session.IsClosed() {
+		s.mu.Unlock()
+		return errors.New("orthrus: cannot start external proxy on closed session")
+	}
+	loopbackPort := s.proxyPort
+	s.mu.Unlock()
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+	if err != nil {
+		s.mu.Lock()
+		s.extProxyPort = port // record attempted port for diagnostics
+		s.extErr = fmt.Errorf("orthrus: bind external proxy port %d: %w", port, err)
+		s.mu.Unlock()
+		return s.extErr
+	}
+
+	loopbackTarget := fmt.Sprintf("127.0.0.1:%d", loopbackPort)
+	targetURL := &url.URL{Scheme: "http", Host: loopbackTarget}
+	rp := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(targetURL)
+			pr.Out.Host = ""
+		},
+		FlushInterval: -1,
+	}
+
+	srv := &http.Server{
+		Handler:           NewMuzzle(rp),
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      0,
+	}
+
+	s.mu.Lock()
+	if s.extListener != nil { // double-check after bind
+		_ = ln.Close()
+		s.mu.Unlock()
+		return errors.New("orthrus: external proxy already started")
+	}
+	s.extListener = ln
+	s.extServer = srv
+	s.extProxyPort = port
+	s.extErr = nil
+	s.mu.Unlock()
+
+	logger.Log().WithField("uuid", s.agentUUID).
+		WithField("port", port).
+		Info("orthrus: external docker proxy started")
+
+	go func() { _ = srv.Serve(ln) }()
+	return nil
+}
+
+// GetExternalProxyStatus returns the runtime state of the external proxy for this session.
+func (s *AgentSession) GetExternalProxyStatus() ExternalProxyStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	active := s.extListener != nil
+	boundAddr := ""
+	activePort := 0
+	if active {
+		boundAddr = s.extListener.Addr().String()
+		if tcpAddr, ok := s.extListener.Addr().(*net.TCPAddr); ok {
+			activePort = tcpAddr.Port
+		}
+	}
+
+	errStr := ""
+	if s.extErr != nil {
+		errStr = s.extErr.Error()
+	}
+
+	connStr := ""
+	if active && activePort > 0 {
+		connStr = fmt.Sprintf("tcp://charon:%d", activePort)
+	}
+
+	return ExternalProxyStatus{
+		ConfiguredPort:   s.extProxyPort,
+		ActivePort:       activePort,
+		BoundAddress:     boundAddr,
+		ConnectionString: connStr,
+		Active:           active,
+		Error:            errStr,
+	}
 }
 
 // Close terminates the proxy listener, cancels the context, and closes the
@@ -221,6 +364,15 @@ func (s *AgentSession) Close() error {
 		// proxyPort is intentionally left non-zero for diagnostic purposes.
 		// GetProxyAddr will not be called on a closed session: the session is
 		// removed from the sessions map before any caller can observe it.
+	}
+
+	if s.extServer != nil {
+		_ = s.extServer.Close()
+		s.extServer = nil
+	}
+	if s.extListener != nil {
+		_ = s.extListener.Close()
+		s.extListener = nil
 	}
 
 	s.cancel()

--- a/backend/internal/orthrus/session_coverage_test.go
+++ b/backend/internal/orthrus/session_coverage_test.go
@@ -1,6 +1,7 @@
 package orthrus
 
 import (
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -81,4 +82,77 @@ func TestAgentSession_GetProxyAddr_WithPort(t *testing.T) {
 
 	addr := sess.GetProxyAddr()
 	assert.Equal(t, "127.0.0.1:8080", addr)
+}
+
+// TestWSNetConn_SetDeadline_ClosedConn_ReturnsError covers the error-return path
+// inside SetDeadline when the underlying SetReadDeadline call fails on a closed conn.
+func TestWSNetConn_SetDeadline_ClosedConn_ReturnsError(t *testing.T) {
+	serverConn, done := testWSPair(t)
+	defer done()
+
+	nc := newWSNetConn(serverConn)
+	// Closing the underlying WebSocket connection invalidates the TCP socket;
+	// the subsequent SetReadDeadline call inside SetDeadline will return an error.
+	_ = serverConn.Close()
+
+	err := nc.SetDeadline(time.Now().Add(time.Second))
+	assert.Error(t, err)
+}
+
+// TestGetExternalProxyStatus_ErrorFieldPopulated covers session.go:336-338 —
+// the errStr assignment when extErr is non-nil.
+func TestGetExternalProxyStatus_ErrorFieldPopulated(t *testing.T) {
+	serverConn, done := testWSPair(t)
+	defer done()
+
+	sess, err := NewAgentSession("ext-err-uuid", "ext-err-agent", serverConn)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	bindErr := errors.New("bind failed: address already in use")
+	sess.mu.Lock()
+	sess.extProxyPort = 9999
+	sess.extErr = bindErr
+	sess.mu.Unlock()
+
+	status := sess.GetExternalProxyStatus()
+	assert.Equal(t, bindErr.Error(), status.Error)
+	assert.Equal(t, 9999, status.ConfiguredPort)
+	assert.False(t, status.Active)
+}
+
+// TestStartExternalProxy_SessionClosed covers session.go:268-271 —
+// the IsClosed guard inside StartExternalProxy.
+func TestStartExternalProxy_SessionClosed(t *testing.T) {
+	sess, _, cleanup := sessionWithLoopback(t)
+	defer cleanup()
+
+	require.NoError(t, sess.Close())
+
+	port := findFreePort(t)
+	err := sess.StartExternalProxy(port)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot start external proxy on closed session")
+}
+
+// TestStartExternalProxy_BindFailure covers session.go:276-282 —
+// the error path when net.Listen fails on an already-bound port.
+func TestStartExternalProxy_BindFailure(t *testing.T) {
+	sess, _, cleanup := sessionWithLoopback(t)
+	defer cleanup()
+
+	// Occupy a port to force the bind to fail.
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer blocker.Close() //nolint:errcheck
+	port := blocker.Addr().(*net.TCPAddr).Port
+
+	err = sess.StartExternalProxy(port)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bind external proxy port")
+
+	status := sess.GetExternalProxyStatus()
+	assert.False(t, status.Active)
+	assert.NotEmpty(t, status.Error)
+	assert.Equal(t, port, status.ConfiguredPort)
 }

--- a/backend/internal/orthrus/session_external_proxy_test.go
+++ b/backend/internal/orthrus/session_external_proxy_test.go
@@ -1,0 +1,300 @@
+package orthrus
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// findFreePort returns an ephemeral TCP port that is currently unbound.
+// There is a brief race window between Close and the subsequent Listen;
+// in practice this is safe for unit tests on Linux with SO_REUSEADDR.
+func findFreePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
+// sessionWithLoopback creates an AgentSession with the loopback Docker proxy
+// already started. clientYamux is the yamux.Client side for the test to use
+// as a mock agent. Call cleanup() when done.
+func sessionWithLoopback(t *testing.T) (sess *AgentSession, clientYamux *yamux.Session, cleanup func()) {
+	t.Helper()
+	serverConn, clientConn, wsCleanup := testWSPairBoth(t)
+
+	cfg := yamux.DefaultConfig()
+	cfg.LogOutput = io.Discard
+	cy, err := yamux.Client(newWSNetConn(clientConn), cfg)
+	require.NoError(t, err)
+
+	s, err := NewAgentSession("ext-test-uuid", "ext-test-agent", serverConn)
+	require.NoError(t, err)
+	require.NoError(t, s.StartDockerProxy())
+
+	return s, cy, func() {
+		_ = cy.Close()
+		_ = s.Close()
+		wsCleanup()
+	}
+}
+
+// serveMockDockerOnYamux accepts yamux streams from clientYamux and serves
+// a minimal HTTP response for each Docker API request.
+func serveMockDockerOnYamux(clientYamux *yamux.Session, responses map[string]string) {
+	go func() {
+		for {
+			stream, err := clientYamux.AcceptStream()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close() //nolint:errcheck
+				typeBuf := make([]byte, 1)
+				if _, err := io.ReadFull(conn, typeBuf); err != nil {
+					return
+				}
+				bufRd := bufio.NewReader(conn)
+				req, err := http.ReadRequest(bufRd)
+				if err != nil {
+					return
+				}
+				defer req.Body.Close()
+				body, ok := responses[req.URL.Path]
+				if !ok {
+					body = `{}`
+				}
+				raw := fmt.Sprintf(
+					"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s",
+					len(body), body,
+				)
+				_, _ = conn.Write([]byte(raw))
+			}(stream)
+		}
+	}()
+}
+
+// U-EXT-01: StartExternalProxy(0) is a no-op — returns nil without binding.
+func TestStartExternalProxy_ZeroPortIsNoOp(t *testing.T) {
+	serverConn, done := testWSPair(t)
+	defer done()
+
+	sess, err := NewAgentSession("ext01-uuid", "ext01-agent", serverConn)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	assert.NoError(t, sess.StartExternalProxy(0))
+	status := sess.GetExternalProxyStatus()
+	assert.False(t, status.Active)
+}
+
+// U-EXT-02: StartExternalProxy before StartDockerProxy returns "loopback proxy not started".
+func TestStartExternalProxy_LoopbackNotStarted(t *testing.T) {
+	serverConn, done := testWSPair(t)
+	defer done()
+
+	sess, err := NewAgentSession("ext02-uuid", "ext02-agent", serverConn)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	port := findFreePort(t)
+	err = sess.StartExternalProxy(port)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loopback proxy not started")
+}
+
+// U-EXT-03: HTTP GET /version via external proxy reaches mock Docker and returns 200.
+func TestStartExternalProxy_FullHTTPChain(t *testing.T) {
+	sess, clientYamux, cleanup := sessionWithLoopback(t)
+	defer cleanup()
+
+	serveMockDockerOnYamux(clientYamux, map[string]string{
+		"/version": `{"Version":"24.0.0","ApiVersion":"1.43"}`,
+	})
+
+	port := findFreePort(t)
+	require.NoError(t, sess.StartExternalProxy(port))
+
+	assert.Eventually(t, func() bool {
+		return sess.GetExternalProxyStatus().Active
+	}, 2*time.Second, 10*time.Millisecond)
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/version", port))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Version")
+}
+
+// U-EXT-04: A second StartExternalProxy call returns "already started".
+func TestStartExternalProxy_Idempotent(t *testing.T) {
+	sess, _, cleanup := sessionWithLoopback(t)
+	defer cleanup()
+
+	port := findFreePort(t)
+	require.NoError(t, sess.StartExternalProxy(port))
+
+	err := sess.StartExternalProxy(port)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already started")
+}
+
+// U-EXT-05: POST to external proxy returns 403 (Muzzle blocks non-GET methods).
+func TestStartExternalProxy_MuzzleBlocksPOST(t *testing.T) {
+	sess, _, cleanup := sessionWithLoopback(t)
+	defer cleanup()
+
+	port := findFreePort(t)
+	require.NoError(t, sess.StartExternalProxy(port))
+
+	assert.Eventually(t, func() bool {
+		return sess.GetExternalProxyStatus().Active
+	}, 2*time.Second, 10*time.Millisecond)
+
+	resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%d/containers/json", port), "application/json", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+// U-EXT-06: GET to a non-allowlisted path returns 403 (Muzzle blocks /exec).
+func TestStartExternalProxy_MuzzleBlocksNonAllowlisted(t *testing.T) {
+	sess, _, cleanup := sessionWithLoopback(t)
+	defer cleanup()
+
+	port := findFreePort(t)
+	require.NoError(t, sess.StartExternalProxy(port))
+
+	assert.Eventually(t, func() bool {
+		return sess.GetExternalProxyStatus().Active
+	}, 2*time.Second, 10*time.Millisecond)
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/exec/abc123/start", port))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+// U-EXT-07: GetExternalProxyStatus when proxy not started returns Active=false.
+func TestGetExternalProxyStatus_NotStarted(t *testing.T) {
+	sess, _, cleanup := sessionWithLoopback(t)
+	defer cleanup()
+
+	status := sess.GetExternalProxyStatus()
+	assert.False(t, status.Active)
+	assert.Equal(t, 0, status.ActivePort)
+	assert.Empty(t, status.BoundAddress)
+	assert.Equal(t, 0, status.ConfiguredPort)
+}
+
+// U-EXT-08: GetExternalProxyStatus when proxy started returns Active=true with correct port.
+func TestGetExternalProxyStatus_Active(t *testing.T) {
+	sess, _, cleanup := sessionWithLoopback(t)
+	defer cleanup()
+
+	port := findFreePort(t)
+	require.NoError(t, sess.StartExternalProxy(port))
+
+	assert.Eventually(t, func() bool {
+		return sess.GetExternalProxyStatus().Active
+	}, 2*time.Second, 10*time.Millisecond)
+
+	status := sess.GetExternalProxyStatus()
+	assert.True(t, status.Active)
+	assert.Equal(t, port, status.ConfiguredPort)
+	assert.Equal(t, port, status.ActivePort)
+	assert.NotEmpty(t, status.BoundAddress)
+}
+
+// U-EXT-09: Close() shuts down the external proxy; subsequent TCP dial is refused.
+func TestClose_ShutdownsExternalProxy(t *testing.T) {
+	sess, _, cleanup := sessionWithLoopback(t)
+	defer cleanup()
+
+	port := findFreePort(t)
+	require.NoError(t, sess.StartExternalProxy(port))
+
+	assert.Eventually(t, func() bool {
+		return sess.GetExternalProxyStatus().Active
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, sess.Close())
+
+	_, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 500*time.Millisecond)
+	assert.Error(t, err, "external proxy port should be closed after session Close()")
+}
+
+// U-EXT-10: After Close(), a new session can bind the same port successfully.
+func TestStartExternalProxy_PortReusableAfterClose(t *testing.T) {
+	sess, _, cleanup := sessionWithLoopback(t)
+	defer cleanup()
+
+	port := findFreePort(t)
+	require.NoError(t, sess.StartExternalProxy(port))
+
+	assert.Eventually(t, func() bool {
+		return sess.GetExternalProxyStatus().Active
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, sess.Close())
+
+	// Create a second session and bind the same port.
+	sess2, _, cleanup2 := sessionWithLoopback(t)
+	defer cleanup2()
+
+	require.NoError(t, sess2.StartExternalProxy(port))
+	assert.Eventually(t, func() bool {
+		return sess2.GetExternalProxyStatus().Active
+	}, 2*time.Second, 10*time.Millisecond)
+
+	status := sess2.GetExternalProxyStatus()
+	assert.True(t, status.Active)
+	assert.Equal(t, port, status.ActivePort)
+}
+
+// Coverage debt: the following lines in session.go and server.go are not
+// exercised by unit tests because the failure conditions they guard against
+// cannot be induced deterministically without modifying production code.
+//
+//   session.go – NewAgentSession yamux error path (L127–128):
+//     yamux.Server never returns an error when given a valid DefaultConfig.
+//     VerifyConfig always passes for the library's own defaults, so the error
+//     branch exists only for library contract compliance and is unreachable in
+//     practice.
+//
+//   session.go – StartDockerProxy net.Listen failure (L160–161):
+//     net.Listen("tcp", "127.0.0.1:0") only fails under OS-level resource
+//     exhaustion (e.g., file-descriptor limit exceeded). This cannot be
+//     triggered reliably in unit tests.
+//
+//   session.go – StartDockerProxy double-check guard (L167–170):
+//     The re-check inside the second lock requires two concurrent goroutines
+//     to both observe s.listener == nil during the first lock window and then
+//     race through net.Listen before either re-acquires the lock. The window
+//     is too narrow to hit deterministically without test hooks in the
+//     production function.
+//
+//   session.go – proxyConn write-stream-type-byte failure (L210–212):
+//     Triggering this path requires the yamux stream to transition to the
+//     "reset" state strictly between the s.session.Open() call (L201) and
+//     the stream.Write() call (L209). Because yamux processes RST frames
+//     asynchronously in a receive goroutine, this race cannot be enforced
+//     without an injection point inside proxyConn itself.
+//
+//   server.go – HandleWebSocket StartDockerProxy warning (L97–99):
+//     Reaching this branch requires a full WebSocket HTTP upgrade, TLS
+//     termination, and agent-registration flow. Coverage belongs in the
+//     integration test suite, not in orthrus package unit tests.

--- a/backend/internal/orthrus/session_proxy_test.go
+++ b/backend/internal/orthrus/session_proxy_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // testWSPairBoth creates a WebSocket server/client pair and returns both sides.
-func testWSPairBoth(t *testing.T) (serverConn *websocket.Conn, clientConn *websocket.Conn, done func()) {
+func testWSPairBoth(t *testing.T) (serverConn, clientConn *websocket.Conn, done func()) {
 	t.Helper()
 
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
@@ -123,6 +123,15 @@ func TestStartDockerProxy_AcceptsAndForwards(t *testing.T) {
 	_, err = io.ReadFull(tcpConn, recv)
 	require.NoError(t, err)
 	assert.Equal(t, msg, recv)
+
+	// Data flows from TCP conn → stream.
+	msg2 := []byte("docker-pong")
+	_, err = tcpConn.Write(msg2)
+	require.NoError(t, err)
+	recv2 := make([]byte, len(msg2))
+	_, err = io.ReadFull(stream, recv2)
+	require.NoError(t, err)
+	assert.Equal(t, msg2, recv2)
 }
 
 // U4 — Close stops the proxy listener; subsequent dials are refused.
@@ -162,4 +171,61 @@ func TestStartDockerProxy_AfterClose(t *testing.T) {
 	assert.Equal(t, "", sess.GetProxyAddr())
 }
 
-// U6: injecting a non-ErrClosed Accept error requires a net.Listener seam; future work.
+// errOnceListener returns a fixed error from Accept and is used to cover the
+// non-net.ErrClosed branch in runProxyListener.
+type errOnceListener struct{ err error }
+
+func (l *errOnceListener) Accept() (net.Conn, error) { return nil, l.err }
+func (l *errOnceListener) Close() error              { return nil }
+func (l *errOnceListener) Addr() net.Addr            { return &net.TCPAddr{} }
+
+// U6 — runProxyListener exits immediately when Accept returns a non-net.ErrClosed error.
+// Covers session.go lines 188-189.
+func TestAgentSession_runProxyListener_NonErrClosedError_Returns(t *testing.T) {
+	serverConn, done := testWSPair(t)
+	defer done()
+
+	sess, err := NewAgentSession("rpl-uuid", "rpl-agent", serverConn)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		sess.runProxyListener(&errOnceListener{err: io.ErrUnexpectedEOF})
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("runProxyListener did not return on non-ErrClosed error")
+	}
+}
+
+// U7 — proxyConn exits quietly when the yamux session is already closed.
+// Covers session.go lines 202-205.
+func TestAgentSession_proxyConn_ClosedSession_ReturnsQuietly(t *testing.T) {
+	serverConn, done := testWSPair(t)
+	defer done()
+
+	sess, err := NewAgentSession("pc-closed-uuid", "pc-agent", serverConn)
+	require.NoError(t, err)
+
+	// Close the yamux session so session.Open() returns an error.
+	require.NoError(t, sess.Close())
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		sess.proxyConn(server)
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("proxyConn did not return on closed session")
+	}
+}

--- a/backend/internal/orthrus/session_proxy_test.go
+++ b/backend/internal/orthrus/session_proxy_test.go
@@ -1,0 +1,165 @@
+package orthrus
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testWSPairBoth creates a WebSocket server/client pair and returns both sides.
+func testWSPairBoth(t *testing.T) (serverConn *websocket.Conn, clientConn *websocket.Conn, done func()) {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	ready := make(chan *websocket.Conn, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		ready <- conn
+	}))
+
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, dialResp, err := websocket.DefaultDialer.Dial(url, nil)
+	require.NoError(t, err)
+	if dialResp != nil {
+		_ = dialResp.Body.Close()
+	}
+
+	srvConn := <-ready
+	return srvConn, client, func() {
+		_ = client.Close()
+		srv.Close()
+	}
+}
+
+// U1 — StartDockerProxy sets a non-empty loopback proxy address.
+func TestStartDockerProxy_SetsProxyAddr(t *testing.T) {
+	serverConn, done := testWSPair(t)
+	defer done()
+
+	sess, err := NewAgentSession("u1-uuid", "u1-agent", serverConn)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	require.NoError(t, sess.StartDockerProxy())
+	addr := sess.GetProxyAddr()
+	assert.NotEmpty(t, addr)
+	assert.True(t, strings.HasPrefix(addr, "127.0.0.1:"), "addr should be loopback: %s", addr)
+}
+
+// U2 — A second StartDockerProxy call returns "already started" and the address is unchanged.
+func TestStartDockerProxy_Idempotent(t *testing.T) {
+	serverConn, done := testWSPair(t)
+	defer done()
+
+	sess, err := NewAgentSession("u2-uuid", "u2-agent", serverConn)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	require.NoError(t, sess.StartDockerProxy())
+	first := sess.GetProxyAddr()
+	require.NotEmpty(t, first)
+
+	err = sess.StartDockerProxy()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already started")
+	assert.Equal(t, first, sess.GetProxyAddr(), "address must not change on second call")
+}
+
+// U3 — Dialing the proxy address delivers streamTypeDocker (0x01) as the first byte
+// on the yamux stream, and data flows bidirectionally.
+func TestStartDockerProxy_AcceptsAndForwards(t *testing.T) {
+	serverConn, clientConn, done := testWSPairBoth(t)
+	defer done()
+
+	sess, err := NewAgentSession("u3-uuid", "u3-agent", serverConn)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	// Build a yamux client from the client websocket conn.
+	cfg := yamux.DefaultConfig()
+	cfg.LogOutput = io.Discard
+	clientYamux, err := yamux.Client(newWSNetConn(clientConn), cfg)
+	require.NoError(t, err)
+	defer func() { _ = clientYamux.Close() }()
+
+	require.NoError(t, sess.StartDockerProxy())
+	addr := sess.GetProxyAddr()
+	require.NotEmpty(t, addr)
+
+	// Dial the proxy; proxyConn will call session.Open() to the client.
+	tcpConn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	defer func() { _ = tcpConn.Close() }()
+
+	// Accept the yamux stream that proxyConn opened toward the client.
+	stream, err := clientYamux.AcceptStream()
+	require.NoError(t, err)
+	defer func() { _ = stream.Close() }()
+
+	// First byte must be streamTypeDocker (0x01).
+	typeBuf := make([]byte, 1)
+	_, err = io.ReadFull(stream, typeBuf)
+	require.NoError(t, err)
+	assert.Equal(t, streamTypeDocker, typeBuf[0])
+
+	// Data flows from stream → TCP conn.
+	msg := []byte("docker-ping")
+	_, err = stream.Write(msg)
+	require.NoError(t, err)
+	recv := make([]byte, len(msg))
+	_, err = io.ReadFull(tcpConn, recv)
+	require.NoError(t, err)
+	assert.Equal(t, msg, recv)
+}
+
+// U4 — Close stops the proxy listener; subsequent dials are refused.
+func TestClose_StopsProxyListener(t *testing.T) {
+	serverConn, done := testWSPair(t)
+	defer done()
+
+	sess, err := NewAgentSession("u4-uuid", "u4-agent", serverConn)
+	require.NoError(t, err)
+
+	require.NoError(t, sess.StartDockerProxy())
+	addr := sess.GetProxyAddr()
+	require.NotEmpty(t, addr)
+
+	require.NoError(t, sess.Close())
+
+	// Listener is closed; connection must be refused.
+	conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("expected dial to fail after session close")
+	}
+}
+
+// U5 — StartDockerProxy on a closed session returns an error without allocating a port.
+func TestStartDockerProxy_AfterClose(t *testing.T) {
+	serverConn, done := testWSPair(t)
+	defer done()
+
+	sess, err := NewAgentSession("u5-uuid", "u5-agent", serverConn)
+	require.NoError(t, err)
+
+	require.NoError(t, sess.Close())
+
+	err = sess.StartDockerProxy()
+	require.Error(t, err)
+	assert.Equal(t, "", sess.GetProxyAddr())
+}
+
+// U6: injecting a non-ErrClosed Accept error requires a net.Listener seam; future work.

--- a/backend/internal/services/orthrus_service.go
+++ b/backend/internal/services/orthrus_service.go
@@ -81,7 +81,7 @@ func (s *OrthrusService) Get(uuid string) (*models.OrthrusAgent, error) {
 }
 
 // Patch applies a partial update to an agent. Only non-nil fields are written.
-func (s *OrthrusService) Patch(uuid string, name, hecateTunnelUUID, deviceID, resolvedAddress *string) (*models.OrthrusAgent, error) {
+func (s *OrthrusService) Patch(uuid string, name, hecateTunnelUUID, deviceID, resolvedAddress *string, externalProxyPort *int) (*models.OrthrusAgent, error) {
 	updates := map[string]interface{}{}
 	if name != nil {
 		trimmed := strings.TrimSpace(*name)
@@ -99,6 +99,13 @@ func (s *OrthrusService) Patch(uuid string, name, hecateTunnelUUID, deviceID, re
 	if resolvedAddress != nil {
 		updates["resolved_address"] = *resolvedAddress
 	}
+	if externalProxyPort != nil {
+		port := *externalProxyPort
+		if port != 0 && (port < 1024 || port > 65535) {
+			return nil, fmt.Errorf("external_proxy_port must be 0 (disabled) or in range 1024–65535, got %d", port)
+		}
+		updates["external_proxy_port"] = port
+	}
 	if len(updates) == 0 {
 		return s.Get(uuid)
 	}
@@ -110,7 +117,7 @@ func (s *OrthrusService) Patch(uuid string, name, hecateTunnelUUID, deviceID, re
 
 // Rename updates the display name of an agent (backward-compat wrapper around Patch).
 func (s *OrthrusService) Rename(uuid, newName string) (*models.OrthrusAgent, error) {
-	return s.Patch(uuid, &newName, nil, nil, nil)
+	return s.Patch(uuid, &newName, nil, nil, nil, nil)
 }
 
 // Delete removes an agent from the database (does not revoke/disconnect first).

--- a/backend/internal/services/orthrus_service_test.go
+++ b/backend/internal/services/orthrus_service_test.go
@@ -289,7 +289,7 @@ func TestOrthrusService_Patch_NameOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	newName := "updated-name"
-	got, err := svc.Patch(agent.UUID, &newName, nil, nil, nil)
+	got, err := svc.Patch(agent.UUID, &newName, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "updated-name", got.Name)
@@ -307,7 +307,7 @@ func TestOrthrusService_Patch_ProviderFields(t *testing.T) {
 	deviceID := "device-id-456"
 	resolved := "10.0.0.1"
 
-	got, err := svc.Patch(agent.UUID, nil, &tunnelUUID, &deviceID, &resolved)
+	got, err := svc.Patch(agent.UUID, nil, &tunnelUUID, &deviceID, &resolved, nil)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "provider-agent", got.Name)
@@ -327,7 +327,7 @@ func TestOrthrusService_Patch_BlankName(t *testing.T) {
 	require.NoError(t, err)
 
 	blank := "   "
-	_, err = svc.Patch(agent.UUID, &blank, nil, nil, nil)
+	_, err = svc.Patch(agent.UUID, &blank, nil, nil, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot be blank")
 }
@@ -339,7 +339,7 @@ func TestOrthrusService_Patch_EmptyUpdate(t *testing.T) {
 	agent, _, err := svc.Provision("no-change-agent")
 	require.NoError(t, err)
 
-	got, err := svc.Patch(agent.UUID, nil, nil, nil, nil)
+	got, err := svc.Patch(agent.UUID, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "no-change-agent", got.Name)
@@ -351,7 +351,7 @@ func TestOrthrusService_Patch_UnknownUUID(t *testing.T) {
 	svc := services.NewOrthrusService(db, setupOrthrusServer(t, db))
 
 	newName := "irrelevant"
-	_, err := svc.Patch("00000000-0000-0000-0000-000000000000", &newName, nil, nil, nil)
+	_, err := svc.Patch("00000000-0000-0000-0000-000000000000", &newName, nil, nil, nil, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
 }
@@ -368,4 +368,71 @@ func TestOrthrusService_Rename_DelegatesToPatch(t *testing.T) {
 	require.NotNil(t, got)
 	assert.Equal(t, "rename-after", got.Name)
 	assert.Equal(t, agent.UUID, got.UUID)
+}
+
+func TestOrthrusService_Patch_ExternalProxyPort_Zero(t *testing.T) {
+	db := setupOrthrusTestDB(t)
+	svc := services.NewOrthrusService(db, setupOrthrusServer(t, db))
+
+	agent, _, err := svc.Provision("port-zero")
+	require.NoError(t, err)
+
+	port := 0
+	got, err := svc.Patch(agent.UUID, nil, nil, nil, nil, &port)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 0, got.ExternalProxyPort)
+}
+
+func TestOrthrusService_Patch_ExternalProxyPort_Valid(t *testing.T) {
+	db := setupOrthrusTestDB(t)
+	svc := services.NewOrthrusService(db, setupOrthrusServer(t, db))
+
+	agent, _, err := svc.Provision("port-valid")
+	require.NoError(t, err)
+
+	port := 2375
+	got, err := svc.Patch(agent.UUID, nil, nil, nil, nil, &port)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 2375, got.ExternalProxyPort)
+}
+
+func TestOrthrusService_Patch_ExternalProxyPort_TooLow(t *testing.T) {
+	db := setupOrthrusTestDB(t)
+	svc := services.NewOrthrusService(db, setupOrthrusServer(t, db))
+
+	agent, _, err := svc.Provision("port-too-low")
+	require.NoError(t, err)
+
+	port := 1023
+	_, err = svc.Patch(agent.UUID, nil, nil, nil, nil, &port)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "external_proxy_port")
+}
+
+func TestOrthrusService_Patch_ExternalProxyPort_TooHigh(t *testing.T) {
+	db := setupOrthrusTestDB(t)
+	svc := services.NewOrthrusService(db, setupOrthrusServer(t, db))
+
+	agent, _, err := svc.Provision("port-too-high")
+	require.NoError(t, err)
+
+	port := 70000
+	_, err = svc.Patch(agent.UUID, nil, nil, nil, nil, &port)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "external_proxy_port")
+}
+
+func TestOrthrusService_Patch_ExternalProxyPort_Negative(t *testing.T) {
+	db := setupOrthrusTestDB(t)
+	svc := services.NewOrthrusService(db, setupOrthrusServer(t, db))
+
+	agent, _, err := svc.Provision("port-negative")
+	require.NoError(t, err)
+
+	port := -1
+	_, err = svc.Patch(agent.UUID, nil, nil, nil, nil, &port)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "external_proxy_port")
 }

--- a/docs/plans/current_spec.md
+++ b/docs/plans/current_spec.md
@@ -1,9 +1,9 @@
-# Orthrus Agent Docker Proxy Listener — Feature Spec (PR 5)
+# Orthrus External Docker Proxy — Feature Spec
 
-**Branch**: `feature/hecate`
-**PR**: #5 (Orthrus Docker Proxy — server-side listener)
-**Date**: 2026-05-18
+**Branch**: `feature/orthrus-external-proxy`
+**Date**: 2026-05-20
 **Status**: Ready for implementation
+**Author**: Principal Architect
 
 ---
 
@@ -11,707 +11,802 @@
 
 ### Overview
 
-Orthrus agents connect to Charon over a persistent WebSocket multiplexed with yamux. The agent binary (`agent/leash/leash.go`) already handles an incoming yamux stream whose first byte is `0x01` (`streamTypeDocker`) by connecting to its local `/var/run/docker.sock` and bidirectionally copying. The server-side half of this tunnel was deferred with the comment "PR 5".
+PR #1031 implemented a server-side Docker proxy listener for the Orthrus subsystem. When an agent connects over WebSocket (yamux-multiplexed), Charon binds an ephemeral `127.0.0.1:N` TCP listener and proxies Docker API traffic through the yamux session to the agent's `/var/run/docker.sock`. This loopback proxy allows Charon itself to discover remote Docker containers.
 
-This spec covers the complete implementation:
+However, **other containers on the Docker network** (e.g., Dockhand) that previously pointed at a dedicated `socat`-based TCP proxy cannot reach `127.0.0.1:N` — loopback is not routable across Docker bridge networks.
 
-1. **Server-side proxy listener** — when an agent session is registered, allocate an ephemeral `127.0.0.1:0` TCP listener; for each accepted connection, open a yamux stream to the agent, write `0x01`, then bidirectionally copy.
-2. **`DockerHandler` integration** — when a `RemoteServer` has `connection_type == "orthrus"`, resolve the agent's proxy address and use `tcp://127.0.0.1:<port>` as the Docker host instead of the server's `Host:Port` fields.
+This spec covers the **External Docker Proxy** extension: an optional HTTP-aware, muzzle-filtered TCP listener on `0.0.0.0:PORT` that bridges the Docker network to the Orthrus agent's Docker socket. Containers on the same Docker network reach the remote daemon via `charon:PORT` without any host port publishing.
 
 ### Objectives
 
-1. `GetProxyAddr()` returns a non-empty address for every live agent session.
-2. Docker container listing via `GET /api/v1/docker/containers?server_id=<uuid>` works for Orthrus-backed remote servers.
-3. Clear 502/503 errors when the agent is offline or the orthrus subsystem is unavailable.
-4. All changes are covered by unit tests; an integration test stub is provided.
+1. Per-agent configurable `external_proxy_port` (0 = disabled, 1024–65535 = enabled).
+2. When an agent with `external_proxy_port > 0` connects, bind `0.0.0.0:PORT` and serve HTTP-filtered (muzzle) Docker API traffic through the loopback proxy → yamux → agent.
+3. API to read and write `external_proxy_port` per agent.
+4. UI to configure the port and display the connection string (`tcp://charon:PORT`).
+5. Graceful degradation: bind failure keeps the loopback proxy intact; agent disconnect closes the external listener immediately.
+6. Full unit test coverage of new code paths.
 
 ---
 
 ## 2. Research Findings
 
-### 2.1 `backend/internal/orthrus/session.go`
+### 2.1 Current loopback proxy (`session.go`)
 
-**`AgentSession` struct** (relevant fields):
+`AgentSession` holds one `net.Listener` (`listener`) bound to `127.0.0.1:0`. `runProxyListener` accepts TCP connections; `proxyConn` opens a yamux stream, writes `0x01` (`streamTypeDocker`), then bidirectionally copies raw bytes. `Close()` closes the listener, cancels the context, and closes the yamux session.
 
-```go
-type AgentSession struct {
-    agentUUID string
-    agentName string
-    conn      *websocket.Conn
-    session   *yamux.Session
-    cancel    context.CancelFunc
-    proxyPort int        // 0 means no proxy listener yet (allocated in PR 5)
-    mu        sync.Mutex
-}
-```
+**Key insight**: `proxyConn` is a raw byte forwarder — there is no HTTP parsing in the current path. `Muzzle` is an `http.Handler` wrapper that cannot intercept raw TCP bytes.
 
-**`GetProxyAddr()`** already returns the correct format, updated to use `s.listener != nil` as the sentinel for consistency with the idempotency guard:
+### 2.2 `OrthrusServer` (`server.go`)
 
-```go
-func (s *AgentSession) GetProxyAddr() string {
-    s.mu.Lock()
-    defer s.mu.Unlock()
-    if s.listener == nil {
-        return ""
-    }
-    return fmt.Sprintf("127.0.0.1:%d", s.proxyPort)
-}
-```
+`HandleWebSocket` calls `session.StartDockerProxy()` (the loopback proxy) immediately after creating the session and before storing it in `sessions`. `watchHeartbeat` polls `IsAlive()` and calls `markOffline` + `sessions.Delete` on disconnect. `watchHeartbeat` already calls `_ = sess.Close()` before `markOffline` (added in PR #1031). The `Close()` method must be **extended** in this PR to also stop the external proxy `http.Server` — this is new work, not a bug fix.
 
-An existing coverage test (`session_coverage_test.go`) manually sets `sess.proxyPort = 8080` and asserts `GetProxyAddr()` returns `"127.0.0.1:8080"` — the integer field remains the source of truth for the port value; `listener` is the guard that determines whether a proxy is active.
+### 2.3 `Muzzle` (`muzzle.go`)
 
-**`Close()`** cancels the context and closes the yamux session (which also closes the underlying WebSocket). The listener allocated in PR 5 must be closed here.
+Allowlist: `GET /containers/json`, `GET /images/json`, `GET /info`, `GET /version` (after stripping `/vN.NN` prefix). All other methods and paths return `403 Forbidden`. It is an `http.Handler` and cannot intercept raw TCP.
 
-**`IsAlive()`** returns `!s.session.IsClosed()`.
+### 2.4 `OrthrusAgent` model
 
-### 2.2 `backend/internal/orthrus/server.go`
+No `external_proxy_port` field currently exists. The model resides in `backend/internal/models/orthrus_agent.go`. GORM AutoMigrate handles schema additions.
 
-**`OrthrusServer`** stores sessions in a `sync.Map` keyed by `agentUUID → *AgentSession`.
+### 2.5 `OrthrusService.Patch`
 
-**`HandleWebSocket()`** — the connection lifecycle:
-1. Authenticates the bearer token (bcrypt compare against all agents).
-2. Calls `NewAgentSession(uuid, name, conn)` to create the yamux server session.
-3. Stores in `sessions`.
-4. Updates the agent's `status = online` in the DB.
-5. Launches `watchHeartbeat` goroutine.
+Accepts `name, hecateTunnelUUID, deviceID, resolvedAddress *string`. The `patchAgentRequest` in the handler mirrors this. Both must be extended to carry `externalProxyPort *int`.
 
-`StartDockerProxy()` (to be added) must be called between steps 2 and 3.
+### 2.6 Docker bridge networking constraint
 
-**`watchHeartbeat()`** polls `sess.IsAlive()` on a ticker. When false, it calls `markOffline` and `s.sessions.Delete(agentUUID)` — but does **not** call `sess.Close()`. This means the listener goroutine would outlive the session. The fix: call `sess.Close()` in `watchHeartbeat` when `!sess.IsAlive()`.
-
-**`GetProxyAddr(agentUUID string) (string, bool)`** and **`GetSession(agentUUID string) (*AgentSession, bool)`** are already implemented as stubs and will work correctly once `proxyPort` is set.
-
-**`Stop()`** already calls `sess.Close()` for all sessions — listener cleanup will be covered once `Close()` is updated.
-
-### 2.3 `backend/internal/api/handlers/docker_handler.go`
-
-**Current struct**:
-
-```go
-type DockerHandler struct {
-    dockerService       dockerContainerLister
-    remoteServerService remoteServerGetter
-}
-```
-
-**Current `ListContainers` flow for `server_id`**:
-
-```go
-server, err := h.remoteServerService.GetByUUID(serverID)
-// ...
-host = fmt.Sprintf("tcp://%s:%d", server.Host, server.Port)
-```
-
-No awareness of `ConnectionType` or `OrthrusAgentUUID`. No reference to `OrthrusServer`.
-
-### 2.4 `backend/internal/api/routes/routes.go`
-
-**Critical wiring gap**: `orthrusServer` is created inside `if strings.TrimSpace(os.Getenv("CHARON_ENCRYPTION_KEY")) != "" { ... }`. The `dockerHandler` is created **after** this block closes:
-
-```go
-if encryptionKey != "" {
-    // ...
-    orthrusServer, _ = orthrus.NewOrthrusServer(db, orthrusCA)
-    // orthrusServer registered with api and caddyManager here
-}
-// dockerHandler created here — orthrusServer is OUT OF SCOPE
-dockerService := services.NewDockerService()
-dockerHandler := handlers.NewDockerHandler(dockerService, remoteServerService)
-dockerHandler.RegisterRoutes(management)
-```
-
-Fix: hoist `var orthrusServer *orthrus.OrthrusServer` declaration above the `if` block, then call `dockerHandler.SetOrthrusResolver(orthrusServer)` (may be nil) after the handler is created.
-
-### 2.5 `backend/internal/services/docker_service.go`
-
-**`ListContainers(ctx, host string)`**: when `host` is neither empty nor `"local"`, creates a new `*client.Client` with `client.WithHost(host)`. A `tcp://127.0.0.1:<port>` value is a valid host string — no changes needed to `docker_service.go`.
-
-### 2.6 `backend/internal/models/remote_server.go`
-
-```go
-type ConnectionType string
-
-const (
-    ConnectionTypeDirect     ConnectionType = "direct"
-    ConnectionTypeOrthrus    ConnectionType = "orthrus"
-    ConnectionTypeCloudflare ConnectionType = "cloudflare"
-    ConnectionTypeTailscale  ConnectionType = "tailscale"
-    ConnectionTypeNetbird    ConnectionType = "netbird"
-    ConnectionTypeZerotier   ConnectionType = "zerotier"
-)
-
-type RemoteServer struct {
-    // ...
-    ConnectionType   ConnectionType `json:"connection_type" gorm:"default:'direct';index"`
-    OrthrusAgentUUID *string        `json:"orthrus_agent_uuid,omitempty" gorm:"index"`
-    // ...
-}
-```
-
-All six values are enumerated here for completeness. Only `orthrus` uses the proxy path; the `default:` branch in `ListContainers` handles all remaining types (`direct`, `cloudflare`, `tailscale`, `netbird`, `zerotier`) correctly by falling through to the `tcp://host:port` construction.
-
-### 2.7 `agent/leash/leash.go` — Agent-side protocol (already implemented)
-
-```go
-const (
-    streamTypeDocker      = byte(0x01)
-    streamTypePortForward = byte(0x02)
-)
-```
-
-**`handleStream(stream *yamux.Stream)`**: reads 1 type byte, dispatches to `handleDockerStream` for `0x01`.
-
-**`handleDockerStream(stream *yamux.Stream)`**: calls `l.filter.ServeProxy(l.dockerSock, stream, stream)` — the `muzzle.Filter` proxies the stream to the local Docker socket, applying the allowlist filter.
-
-**Server-side requirement**: open a yamux stream (`s.session.Open()`), write `[]byte{0x01}`, then bidirectionally copy between the TCP connection and the yamux stream.
-
-### 2.8 Existing Tests
-
-- `session_coverage_test.go` directly accesses `sess.proxyPort` (unexported). The new `StartDockerProxy()` sets this field — existing test remains valid.
-- `docker_handler_test.go` uses `fakeDockerService` and `fakeRemoteServerService`. New tests will add a `fakeOrthrusResolver`.
-- `server_test.go` uses a real SQLite DB and real WebSocket pairs. New tests will exercise the proxy listener start/stop lifecycle.
+`0.0.0.0:PORT` inside the Charon container is reachable from other containers on the **same Docker network** by name (`charon:PORT`) without any `-p HOST:CONTAINER` port publishing. This is the desired behavior. Publishing the port to the host is an explicit user action with security implications (documented in §9).
 
 ---
 
-## 3. Technical Specifications
+## 3. Requirements (EARS Notation)
 
-### 3.1 New Constant
+### 3.1 Configuration
 
-**File**: `backend/internal/orthrus/session.go`
+- **R1**: WHEN an admin sends `PATCH /api/v1/orthrus/agents/:uuid` with `{"external_proxy_port": N}` where `N ∈ {0} ∪ [1024, 65535]`, THE SYSTEM SHALL persist the value to the `orthrus_agents` row.
+- **R2**: WHEN `N` is outside the valid range (1–1023 or > 65535) or negative, THE SYSTEM SHALL return HTTP 400 with a descriptive error message.
+- **R3**: THE SYSTEM SHALL default `external_proxy_port` to `0` for all new and migrated agents.
 
-```go
-// streamTypeDocker is the yamux stream type byte for Docker socket proxy traffic.
-// Must match streamTypeDocker in the Orthrus agent (agent/leash/leash.go).
-const streamTypeDocker = byte(0x01)
+### 3.2 Proxy Lifecycle
+
+- **R4**: WHEN an agent whose `external_proxy_port > 0` establishes a WebSocket connection, THE SYSTEM SHALL bind a TCP listener on `0.0.0.0:<external_proxy_port>` after the loopback proxy listener is successfully started.
+- **R5**: WHEN the external proxy port bind fails (e.g., port already in use), THE SYSTEM SHALL log a warning, NOT start the external listener, AND NOT prevent the loopback proxy from operating.
+- **R6**: WHEN an agent session is closed (disconnect, heartbeat timeout, or revocation), THE SYSTEM SHALL close the external proxy listener and its `http.Server` within the same `Close()` call.
+- **R7**: WHEN the agent is disconnected and a client attempts to connect to `0.0.0.0:<PORT>`, THE SYSTEM SHALL refuse the TCP connection (port not listening).
+- **R8**: WHEN an agent with `external_proxy_port = 0` connects, THE SYSTEM SHALL NOT bind any external listener.
+
+### 3.3 Request Filtering
+
+- **R9**: WHEN a client connects to the external proxy port and sends a Docker API request, THE SYSTEM SHALL apply muzzle filtering before forwarding any bytes to the agent.
+- **R10**: WHEN a client sends a request to a non-allowlisted path or uses a non-GET method, THE SYSTEM SHALL return HTTP 403 and SHALL NOT open a yamux stream.
+- **R11**: WHEN a client sends a valid muzzle-allowlisted GET request, THE SYSTEM SHALL forward it through the loopback proxy → yamux → agent's Docker socket and return the response to the client.
+
+### 3.4 Concurrency
+
+- **R12**: WHEN multiple clients connect simultaneously to the external proxy port, THE SYSTEM SHALL handle each connection concurrently in independent goroutines.
+- **R13**: WHEN an agent reconnects after disconnect, THE SYSTEM SHALL successfully re-bind the same `external_proxy_port` (because the old listener was closed by `Close()`).
+
+### 3.5 Status API
+
+- **R14**: WHEN an admin calls `GET /api/v1/orthrus/agents/:uuid/proxy-status`, THE SYSTEM SHALL return the live external proxy state: configured port, bound address (if active), and whether the listener is currently active.
+
+### 3.6 UI
+
+- **R15**: WHEN viewing an Orthrus agent in the management UI, THE SYSTEM SHALL display an "External Docker Proxy" section with a port input field and a status indicator.
+- **R16**: WHEN the external proxy is active, THE SYSTEM SHALL prominently display the connection string `tcp://charon:<PORT>` for copy-paste use.
+
+---
+
+## 4. Architecture Decision Records
+
+### ADR-01: Port Assignment Strategy
+
+**Decision**: Store `external_proxy_port int` on the `OrthrusAgent` model. Port `0` means disabled. Users set any value in `[1024, 65535]`. Ephemeral assignment is explicitly rejected.
+
+**Context**: Dockhand and similar tools must know the port in advance to configure their Docker host. Ephemeral ports change on every Charon restart and every agent reconnect, making them unworkable for static container configuration.
+
+**Options**:
+
+- A. Ephemeral-and-stored: Assign a random port on first agent connect, persist it. Complex — requires write-back from runtime to DB; race conditions during initial connect.
+- B. User-configured fixed port: User chooses the port, stored in DB. Simplest, most operationally predictable. **SELECTED**.
+- C. Range-allocated pool: Charon manages a pool. Unnecessary complexity.
+
+**Rationale**: Option B aligns with how operators configure Docker proxy endpoints (`socat` to a fixed port, `dockerd --host tcp://0.0.0.0:2375`). The value persists across Charon restarts. The agent reconnect scenario is clean: the port was freed when the old session closed, so rebinding succeeds.
+
+**Impact**: DB migration adds one `int` column. No schema complexities.
+
+---
+
+### ADR-02: Bind Address
+
+**Decision**: Always bind `0.0.0.0:<PORT>` for the external proxy. Not configurable in this release.
+
+**Context**: The entire motivation is that containers on the Docker bridge network need to reach `charon:PORT`. A loopback-only bind defeats this purpose entirely.
+
+**Options**:
+
+- A. Loopback `127.0.0.1`: Useless for the stated goal.
+- B. `0.0.0.0` (all interfaces): Reachable from Docker network peers. Also reachable from the Docker host and potentially external networks if the port is published. **SELECTED**.
+- C. Docker bridge interface IP (e.g., `172.17.0.X`): Restricts to Docker network only but requires runtime inspection of container network config — unacceptable complexity.
+
+**Rationale**: Option B is simple and correct. The Docker bridge network is an internal network. Exposure to external networks only occurs via explicit user `-p PORT:PORT` publishing.
+
+**Security Mitigations**: Muzzle filtering (R9–R10); UI warning; §9 documentation.
+
+---
+
+### ADR-03: Muzzle Integration Architecture
+
+**Decision**: The external proxy is an `http.Server` fronted by `Muzzle`, reverse-proxying to the loopback `127.0.0.1:<loopback_port>`. The raw TCP tunnel layer (`proxyConn`) remains unchanged.
+
+**Proxy chain**:
+
+```
+Docker client → net/http.Server (0.0.0.0:PORT)
+  → Muzzle (http.Handler — allowlist gate)
+    → httputil.ReverseProxy (Director rewrites Host to 127.0.0.1:loopbackPort)
+      → runProxyListener (existing loopback)
+        → proxyConn (yamux stream + streamTypeDocker byte)
+          → agent /var/run/docker.sock
 ```
 
-### 3.2 `AgentSession` Struct Changes
+**Why not raw TCP forwarding?** Muzzle cannot filter raw TCP bytes; HTTP parsing is mandatory for allowlist enforcement.
 
-**File**: `backend/internal/orthrus/session.go`
+**Why not parse HTTP in `proxyConn`?** That would muzzle Charon's own loopback Docker access, adding complexity to a path that works correctly today.
 
-Add one field to `AgentSession`:
+**Streaming support**: `httputil.ReverseProxy.FlushInterval = -1` (flush immediately) handles Docker log/event streaming. `http.Server.WriteTimeout = 0` prevents premature termination of long-lived streaming responses. `ReadHeaderTimeout = 10s` guards against Slowloris.
+
+**Double-filtering**: Muzzle applied at Charon (external entry) AND at agent (existing leash code). Defense in depth.
+
+---
+
+### ADR-04: Bind Timing
+
+**Decision**: Bind eagerly on agent connect, same pattern as the loopback proxy.
+
+**Rationale**: Consistent observable state — the port is either listening or not; there is no transient window. If bind fails, the error is stored and surfaced via the status endpoint.
+
+---
+
+### ADR-05: Port Change During Active Session
+
+**Decision**: Port changes take effect on the **next agent connection**. Running sessions are not dynamically reconfigured.
+
+**Rationale**: Dynamic reconfiguration requires stopping the `http.Server` while HTTP connections may be in flight, adding locking complexity. Administrative port changes are rare.
+
+**UI signal**: Display live active port (from `/proxy-status`) alongside configured port. When they differ: *"Changes will take effect on next agent reconnect."*
+
+---
+
+### ADR-06: `external_proxy_port` Model Location
+
+**Decision**: Store on `OrthrusAgent`, not `RemoteServer`.
+
+**Rationale**: The external proxy is a property of the agent's Docker socket exposure. Multiple `RemoteServer` records can reference the same `OrthrusAgent`; the proxy port should be configured once. Storing it on `OrthrusAgent` maintains cohesion between the port and the session lifecycle that owns the listener.
+
+---
+
+### ADR-07: `Close()` Must Cover the External Proxy Server
+
+**Decision**: Extend `AgentSession.Close()` to shut down the `extServer` (`http.Server`) and its `extListener` in addition to the existing loopback listener teardown.
+
+**Context**: `watchHeartbeat` already calls `sess.Close()` (PR #1031). When the external proxy is added, `Close()` must also call `extServer.Close()` to stop the HTTP server and free the external listener port. Without this, the port would remain bound and refuse re-binding on agent reconnect (R13).
+
+**No change required to `watchHeartbeat` itself** — it already calls `sess.Close()` before `markOffline`.
+
+---
+
+## 5. Database Schema
+
+### 5.1 Change: `orthrus_agents` table
+
+Add one column:
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `external_proxy_port` | `INTEGER` | `0` | `0` = disabled; `1024`–`65535` = external proxy port |
+
+**GORM field**:
 
 ```go
-type AgentSession struct {
-    agentUUID string
-    agentName string
-    conn      *websocket.Conn
-    session   *yamux.Session
-    cancel    context.CancelFunc
-    proxyPort int          // ephemeral port; 0 until StartDockerProxy succeeds
-    listener  net.Listener // nil until StartDockerProxy succeeds
-    mu        sync.Mutex
+// ExternalProxyPort is the TCP port bound on 0.0.0.0 for inter-container Docker API access.
+// 0 = disabled. Valid range: 1024–65535.
+ExternalProxyPort int `json:"external_proxy_port" gorm:"default:0"`
+```
+
+**Migration**: GORM AutoMigrate adds the column automatically at startup. Existing rows default to `0` (disabled). No explicit migration script required.
+
+### 5.2 No new tables
+
+---
+
+## 6. Backend Implementation Plan
+
+### 6.1 `backend/internal/models/orthrus_agent.go`
+
+Add `ExternalProxyPort` field after `ResolvedAddress`:
+
+```go
+// ExternalProxyPort is the TCP port bound on 0.0.0.0 for inter-container Docker API access.
+// 0 = disabled. Valid values: 1024–65535.
+ExternalProxyPort int `json:"external_proxy_port" gorm:"default:0"`
+```
+
+---
+
+### 6.2 `backend/internal/orthrus/session.go`
+
+#### New fields on `AgentSession`
+
+```go
+extServer    *http.Server  // nil if external proxy disabled/not started
+extListener  net.Listener  // nil until StartExternalProxy succeeds
+extProxyPort int           // the port arg passed to StartExternalProxy; 0 if not started
+extErr       error         // last bind error; nil on success
+```
+
+New imports required: `"net/http"`, `"net/http/httputil"`, `"net/url"`, `"time"`, `"errors"`.
+
+#### New method: `StartExternalProxy(port int) error`
+
+Signature:
+
+```go
+func (s *AgentSession) StartExternalProxy(port int) error
+```
+
+Behaviour:
+
+1. `port == 0` → return nil immediately (no-op; R8).
+2. Lock `s.mu`. If `s.proxyPort == 0` → return "loopback proxy not started" error.
+3. If `s.extListener != nil` → return "already started" error.
+4. If `s.session.IsClosed()` → return "closed session" error.
+5. Read `loopbackPort = s.proxyPort`. Unlock.
+6. `net.Listen("tcp", "0.0.0.0:PORT")`. On failure: lock, store `extErr`, unlock, return error (R5).
+7. Create `httputil.ReverseProxy` targeting `http://127.0.0.1:loopbackPort`; `FlushInterval = -1`.
+8. Create `http.Server{Handler: NewMuzzle(rp), ReadHeaderTimeout: 10s}`.
+9. Lock. Double-check `s.extListener == nil` (concurrent call guard). Store `extListener`, `extServer`, `extProxyPort`. Unlock.
+10. `go srv.Serve(ln)`.
+11. Log at INFO: "orthrus: external docker proxy started".
+12. Return nil.
+
+#### New method: `GetExternalProxyStatus() ExternalProxyStatus`
+
+Returns a snapshot of `extProxyPort`, `extListener.Addr()`, `extListener != nil`, `extErr`.
+
+New exported type `ExternalProxyStatus`:
+
+```go
+type ExternalProxyStatus struct {
+    ConfiguredPort int    `json:"configured_port"` // value passed to StartExternalProxy
+    ActivePort     int    `json:"active_port"`     // 0 if not active
+    BindAddress    string `json:"bind_address"`    // "0.0.0.0:PORT" or ""
+    Active         bool   `json:"active"`
+    Error          string `json:"error,omitempty"` // bind error text, if any
 }
 ```
 
-**`GetProxyAddr()` sentinel updated** — the nil-check changes from `s.proxyPort == 0` to `s.listener == nil` for consistency with the idempotency guard introduced in `StartDockerProxy()`. The integer `s.proxyPort` field continues to hold the ephemeral port value and is still set atomically alongside `s.listener`.
+#### Updated `Close()`
 
-### 3.3 `StartDockerProxy()` Method
-
-**File**: `backend/internal/orthrus/session.go`
+Add before existing `s.cancel()` call:
 
 ```go
-// StartDockerProxy allocates an ephemeral TCP listener on localhost and starts
-// accepting connections. Each accepted connection is proxied to the agent's
-// Docker socket via a new yamux stream with stream type 0x01.
-// Returns an error if the listener cannot be bound or if the proxy has already
-// been started for this session (idempotency guard).
-func (s *AgentSession) StartDockerProxy() error {
-    s.mu.Lock()
-    if s.listener != nil {
-        s.mu.Unlock()
-        return fmt.Errorf("orthrus: docker proxy already started for session %s", s.agentUUID)
-    }
-    s.mu.Unlock()
-
-    ln, err := net.Listen("tcp", "127.0.0.1:0")
-    if err != nil {
-        return fmt.Errorf("orthrus: allocate proxy listener: %w", err)
-    }
-
-    port := ln.Addr().(*net.TCPAddr).Port
-
-    s.mu.Lock()
-    s.listener = ln
-    s.proxyPort = port
-    s.mu.Unlock()
-
-    go s.runProxyListener(ln)
-    return nil
+if s.extServer != nil {
+    _ = s.extServer.Close() // closes extListener internally
+    s.extServer = nil
+}
+if s.extListener != nil { // defensive; http.Server.Close covers this
+    _ = s.extListener.Close()
+    s.extListener = nil
 }
 ```
 
-### 3.4 `runProxyListener()` and `proxyConn()` Methods
+---
 
-**File**: `backend/internal/orthrus/session.go`
+### 6.3 `backend/internal/orthrus/server.go`
 
-```go
-// runProxyListener accepts TCP connections and proxies each to the agent's
-// Docker socket via a new yamux stream. Exits when the listener is closed.
-func (s *AgentSession) runProxyListener(ln net.Listener) {
-    for {
-        conn, err := ln.Accept()
-        if err != nil {
-            // Listener closed — normal shutdown.
-            return
-        }
-        go s.proxyConn(conn)
-    }
-}
-
-// proxyConn opens a yamux stream for Docker proxy traffic, writes the type byte,
-// then bidirectionally copies until either side closes.
-func (s *AgentSession) proxyConn(conn net.Conn) {
-    defer conn.Close()
-
-    stream, err := s.session.Open()
-    if err != nil {
-        // yamux session already closed; nothing to proxy.
-        return
-    }
-    defer stream.Close()
-
-    if _, err := stream.Write([]byte{streamTypeDocker}); err != nil {
-        return
-    }
-
-    var wg sync.WaitGroup
-    wg.Add(2)
-    go func() {
-        defer wg.Done()
-        defer stream.Close()
-        io.Copy(stream, conn) //nolint:errcheck
-    }()
-    go func() {
-        defer wg.Done()
-        defer conn.Close()
-        io.Copy(conn, stream) //nolint:errcheck
-    }()
-    wg.Wait()
-}
-```
-
-### 3.5 `Close()` Changes
-
-**File**: `backend/internal/orthrus/session.go`
-
-Close the listener in addition to the yamux session:
+#### `HandleWebSocket` — call `StartExternalProxy` after `StartDockerProxy`
 
 ```go
-func (s *AgentSession) Close() error {
-    s.mu.Lock()
-    defer s.mu.Unlock()
-
-    s.cancel()
-
-    if s.listener != nil {
-        _ = s.listener.Close()
-        s.listener = nil
-    }
-
-    return s.session.Close()
-}
-```
-
-### 3.6 `server.go` — `HandleWebSocket` Changes
-
-**File**: `backend/internal/orthrus/server.go`
-
-After creating the session and before storing it, start the proxy listener:
-
-```go
-session, err := NewAgentSession(agent.UUID, agent.Name, conn)
-if err != nil {
-    logger.Log().WithError(err).Error("orthrus: create agent session failed")
-    _ = conn.Close()
-    return
-}
-
 if err := session.StartDockerProxy(); err != nil {
     logger.Log().WithField("uuid", util.SanitizeForLog(agent.UUID)).
-        WithError(err).Warn("orthrus: failed to start docker proxy listener — Docker tunneling unavailable for this session")
-    // Non-fatal: session still registered; GetProxyAddr() returns "" -> Docker handler returns 502
+        WithError(err).Warn("orthrus: failed to start loopback docker proxy")
 }
 
-s.sessions.Store(agent.UUID, session)
-```
-
-### 3.7 `server.go` — `watchHeartbeat` Changes
-
-**File**: `backend/internal/orthrus/server.go`
-
-Call `sess.Close()` when the yamux session is found dead to ensure the listener goroutine exits:
-
-```go
-if !sess.IsAlive() {
-    _ = sess.Close() // closes listener goroutine; idempotent
-    s.markOffline(agentUUID)
-    s.sessions.Delete(agentUUID)
-    return
+// agent.ExternalProxyPort == 0 is a no-op in StartExternalProxy.
+if err := session.StartExternalProxy(agent.ExternalProxyPort); err != nil {
+    logger.Log().WithField("uuid", util.SanitizeForLog(agent.UUID)).
+        WithField("port", agent.ExternalProxyPort).
+        WithError(err).Warn("orthrus: failed to start external docker proxy")
 }
 ```
 
-### 3.8 `docker_handler.go` — New Interface and Field
+#### `watchHeartbeat` — fix goroutine leak (ADR-07)
 
-**File**: `backend/internal/api/handlers/docker_handler.go`
+Add `_ = sess.Close()` before `s.markOffline(agentUUID)` and `s.sessions.Delete(agentUUID)`.
 
-Add interface and field:
-
-```go
-// orthrusProxyResolver resolves the local TCP proxy address for a connected Orthrus agent.
-// The address is in "host:port" form, suitable for use as tcp://host:port with Docker.
-type orthrusProxyResolver interface {
-    GetProxyAddr(agentUUID string) (string, bool)
-}
-
-type DockerHandler struct {
-    dockerService       dockerContainerLister
-    remoteServerService remoteServerGetter
-    orthrusResolver     orthrusProxyResolver // nil when Orthrus subsystem is unavailable
-}
-```
-
-**`NewDockerHandler` signature is unchanged.** Add a setter following the existing `caddyManager.SetOrthrusServer` pattern:
+#### New method: `GetExternalProxyStatus(agentUUID string) (ExternalProxyStatus, bool)`
 
 ```go
-// SetOrthrusResolver configures the Orthrus proxy resolver for Docker tunneling.
-// If never called (or called with nil), requests for Orthrus-backed servers
-// return 503 Service Unavailable.
-func (h *DockerHandler) SetOrthrusResolver(r orthrusProxyResolver) {
-    h.orthrusResolver = r
-}
-```
-
-### 3.9 `docker_handler.go` — `ListContainers` Logic
-
-**File**: `backend/internal/api/handlers/docker_handler.go`
-
-Replace the single `host = fmt.Sprintf(...)` line in the `serverID != ""` branch with connection-type-aware logic:
-
-```go
-if serverID != "" {
-    server, err := h.remoteServerService.GetByUUID(serverID)
-    if err != nil {
-        log.WithFields(map[string]any{"server_id": util.SanitizeForLog(serverID)}).Warn("remote server not found")
-        c.JSON(http.StatusNotFound, gin.H{"error": "Remote server not found"})
-        return
+func (s *OrthrusServer) GetExternalProxyStatus(agentUUID string) (ExternalProxyStatus, bool) {
+    raw, ok := s.sessions.Load(agentUUID)
+    if !ok {
+        return ExternalProxyStatus{}, false
     }
-
-    switch server.ConnectionType {
-    case models.ConnectionTypeOrthrus:
-        if h.orthrusResolver == nil {
-            c.JSON(http.StatusServiceUnavailable, gin.H{
-                "error":   "Orthrus subsystem unavailable",
-                "details": "The Orthrus agent tunnel service is not running. Ensure CHARON_ENCRYPTION_KEY is set.",
-            })
-            return
-        }
-        if server.OrthrusAgentUUID == nil || *server.OrthrusAgentUUID == "" {
-            c.JSON(http.StatusBadRequest, gin.H{"error": "Remote server has no linked Orthrus agent"})
-            return
-        }
-        addr, ok := h.orthrusResolver.GetProxyAddr(*server.OrthrusAgentUUID)
-        if !ok {
-            log.WithFields(map[string]any{"agent_uuid": util.SanitizeForLog(*server.OrthrusAgentUUID)}).Warn("orthrus agent not connected")
-            c.JSON(http.StatusBadGateway, gin.H{
-                "error":   "Orthrus agent is not currently connected",
-                "details": "The Orthrus agent for this server is offline. Please ensure the agent is running and connected to Charon.",
-            })
-            return
-        }
-        host = "tcp://" + addr // e.g. tcp://127.0.0.1:54321
-
-    default:
-        // Direct, Tailscale, NetBird, ZeroTier, Cloudflare — use explicit host/port
-        host = fmt.Sprintf("tcp://%s:%d", server.Host, server.Port)
-    }
+    return raw.(*AgentSession).GetExternalProxyStatus(), true
 }
 ```
 
-### 3.10 `routes.go` — Hoist `orthrusServer` and Wire Resolver
+---
 
-**File**: `backend/internal/api/routes/routes.go`
+### 6.4 `backend/internal/services/orthrus_service.go`
 
-1. Hoist the variable declaration before the encryption-key `if` block:
+#### Updated `Patch` signature
+
+Add `externalProxyPort *int` parameter.
+
+#### Validation
 
 ```go
-// Declared here so dockerHandler (created below the if-block) can access it.
-var orthrusServer *orthrus.OrthrusServer
+if externalProxyPort != nil {
+    port := *externalProxyPort
+    if port != 0 && (port < 1024 || port > 65535) {
+        return nil, fmt.Errorf("orthrus: external_proxy_port must be 0 (disabled) or in range [1024, 65535], got %d", port)
+    }
+    updates["external_proxy_port"] = port
+}
 ```
 
-2. Remove the `var orthrusServer *orthrus.OrthrusServer` declaration inside the `if` block (it becomes an assignment only).
+---
 
-3. After `dockerHandler` is created (outside the block), wire the resolver:
+### 6.5 `backend/internal/api/handlers/orthrus_handler.go`
+
+#### Updated `patchAgentRequest`
+
+Add:
 
 ```go
-dockerService := services.NewDockerService()
-dockerHandler := handlers.NewDockerHandler(dockerService, remoteServerService)
+ExternalProxyPort *int `json:"external_proxy_port"` // 0=disabled, 1024-65535=enabled
+```
+
+#### Updated `Patch` handler call
+
+Pass `req.ExternalProxyPort` as the new final argument to `h.svc.Patch(...)`.
+
+#### New interface + field on `OrthrusHandler`
+
+```go
+type orthrusProxyStatusResolver interface {
+    GetExternalProxyStatus(agentUUID string) (orthrus.ExternalProxyStatus, bool)
+}
+
+type OrthrusHandler struct {
+    svc           *services.OrthrusService
+    proxyResolver orthrusProxyStatusResolver // nil when orthrus server unavailable
+}
+
+// SetProxyResolver wires the live proxy status source.
+// Uses reflect nil-guard (same pattern as DockerHandler.SetOrthrusResolver).
+func (h *OrthrusHandler) SetProxyResolver(r orthrusProxyStatusResolver) { ... }
+```
+
+#### New handler: `GetProxyStatus`
+
+Route: `GET /orthrus/agents/:uuid/proxy-status` (added in `RegisterRoutes`).
+
+Logic:
+
+1. `h.svc.Get(uuid)` → 404 if not found.
+2. Build base response with `configured_port` and `agent_online`.
+3. If `h.proxyResolver == nil` → return with `active: false`, `error: "orthrus subsystem unavailable"`.
+4. `h.proxyResolver.GetExternalProxyStatus(uuid)` → if not connected, `active: false`.
+5. If connected and active: populate `active_port`, `bind_address`, `connection_string: "tcp://charon:PORT"`.
+6. If connected but error: populate `error` field.
+
+---
+
+### 6.6 `backend/internal/api/routes/routes.go`
+
+After `orthrusHandler.RegisterRoutes(management)`, add:
+
+```go
 if orthrusServer != nil {
-    dockerHandler.SetOrthrusResolver(orthrusServer)
-}
-dockerHandler.RegisterRoutes(management)
-```
-
----
-
-## 4. Data Flow
-
-### 4.1 Happy Path — Orthrus Agent Connected
-
-```
-Client
-  → GET /api/v1/docker/containers?server_id=<uuid>
-  → DockerHandler.ListContainers
-      → remoteServerService.GetByUUID(uuid)
-          → RemoteServer{connection_type: "orthrus", orthrus_agent_uuid: "agent-abc"}
-      → h.orthrusResolver.GetProxyAddr("agent-abc")
-          → AgentSession.proxyPort = 54321
-          → returns ("127.0.0.1:54321", true)
-      → host = "tcp://127.0.0.1:54321"
-      → dockerService.ListContainers(ctx, "tcp://127.0.0.1:54321")
-          → Docker client dials 127.0.0.1:54321
-          → TCP connection accepted by AgentSession.runProxyListener
-          → AgentSession.proxyConn:
-              → session.Open() → new yamux stream
-              → stream.Write([]byte{0x01})
-              → io.Copy(stream, conn) / io.Copy(conn, stream)
-          → yamux stream arrives at agent
-          → agent.handleDockerStream:
-              → filter.ServeProxy("/var/run/docker.sock", stream, stream)
-              → HTTP request forwarded to local Docker API
-          → Docker API response returns through tunnel
-      → []DockerContainer returned
-  → 200 OK JSON
-```
-
-### 4.2 Agent Disconnected — 502
-
-```
-GET /api/v1/docker/containers?server_id=<uuid>
-→ server.ConnectionType == "orthrus"
-→ h.orthrusResolver.GetProxyAddr("agent-abc") → ("", false)
-→ 502 Bad Gateway {"error": "Orthrus agent is not currently connected", ...}
-```
-
-### 4.3 Orthrus Subsystem Unavailable (no encryption key) — 503
-
-```
-GET /api/v1/docker/containers?server_id=<uuid>
-→ server.ConnectionType == "orthrus"
-→ h.orthrusResolver == nil
-→ 503 Service Unavailable {"error": "Orthrus subsystem unavailable", ...}
-```
-
-### 4.4 Session Disconnect — Listener Cleanup
-
-```
-watchHeartbeat: sess.IsAlive() == false
-  → sess.Close()
-      → s.listener.Close()       ← runProxyListener exits Accept() loop
-      → s.session.Close()
-  → markOffline(agentUUID)
-  → s.sessions.Delete(agentUUID)
-```
-
-> **Async goroutine completion**: `proxyConn` goroutines launched from `runProxyListener` complete asynchronously after `Close()` returns. They are bounded by the time to flush in-flight `io.Copy` calls, which is safe because closing the yamux session terminates all streams, causing the in-flight `io.Copy` on the stream side to return promptly.
-
----
-
-## 5. Error Handling and Edge Cases
-
-| Scenario | Where Detected | Response |
-|----------|---------------|----------|
-| Agent not connected | `GetProxyAddr` returns `("", false)` | `ListContainers` → 502 Bad Gateway |
-| Orthrus subsystem unavailable | `h.orthrusResolver == nil` | `ListContainers` → 503 Service Unavailable |
-| `OrthrusAgentUUID` is nil/empty on the server record | `server.OrthrusAgentUUID == nil` check | `ListContainers` → 400 Bad Request |
-| Port allocation failure on connect | `net.Listen` returns error | `HandleWebSocket` logs warning; session registered with `proxyPort == 0`; Docker returns 502 |
-| Agent disconnects mid-request | `io.Copy` returns error | `proxyConn` exits; Docker client gets connection reset; `ListContainers` returns error → 503 |
-| yamux stream open failure | `session.Open()` returns error | `proxyConn` returns; TCP conn closed; Docker client retries or fails |
-| Concurrent `Close()` calls | `s.mu.Lock()` in `Close()`, `listener = nil` after close | Idempotent; second call is a no-op for the listener |
-| `StartDockerProxy` called a second time | `s.listener != nil` guard under mutex | Returns error; caller logs and skips; no new listener |
-
----
-
-## 6. Files Changed
-
-| File | Change Type | Summary |
-|------|-------------|---------|
-| `backend/internal/orthrus/session.go` | Modify | Add `streamTypeDocker` constant, `listener net.Listener` field, `StartDockerProxy()`, `runProxyListener()`, `proxyConn()`, update `Close()` |
-| `backend/internal/orthrus/server.go` | Modify | Call `session.StartDockerProxy()` in `HandleWebSocket`; call `sess.Close()` in `watchHeartbeat` cleanup |
-| `backend/internal/api/handlers/docker_handler.go` | Modify | Add `orthrusProxyResolver` interface, `orthrusResolver` field, `SetOrthrusResolver()`, update `ListContainers` switch on `ConnectionType` |
-| `backend/internal/api/routes/routes.go` | Modify | Hoist `var orthrusServer` declaration; call `dockerHandler.SetOrthrusResolver(orthrusServer)` |
-| `backend/internal/orthrus/session_test.go` | Modify | Add proxy lifecycle tests |
-| `backend/internal/orthrus/server_test.go` | Modify | Add test for proxy start on session connect |
-| `backend/internal/api/handlers/docker_handler_test.go` | Modify | Add orthrus resolver tests |
-| `backend/internal/orthrus/proxy_integration_test.go` | Create | Integration test stub (`//go:build integration`) |
-
----
-
-## 7. Implementation Plan
-
-### Phase 1 — Playwright Tests (UI/UX Specification)
-
-Write Playwright tests that define expected behavior before implementation. These will fail until the backend is wired up.
-
-**File**: `tests/docker-orthrus-proxy.spec.ts`
-
-Tests:
-1. **Agent offline** — with a remote server that has `connection_type: "orthrus"` and an agent that is offline, the Docker containers panel shows a "Orthrus agent is not currently connected" error state.
-2. **No `server_id`** — local Docker containers still load normally (no regression).
-
-These tests validate the UI error handling introduced by the new 502/503 responses.
-
-### Phase 2 — Backend: Session Proxy Listener
-
-**Files**: `session.go`, `server.go`
-
-- [ ] Add `streamTypeDocker = byte(0x01)` constant to `session.go`
-- [ ] Add `listener net.Listener` field to `AgentSession`
-- [ ] Implement `StartDockerProxy() error`
-- [ ] Implement `runProxyListener(ln net.Listener)`
-- [ ] Implement `proxyConn(conn net.Conn)`
-- [ ] Update `Close()` to close `s.listener` (under mutex, set to nil)
-- [ ] In `HandleWebSocket`: call `session.StartDockerProxy()`, log warning on failure (non-fatal)
-- [ ] In `watchHeartbeat`: call `sess.Close()` before `markOffline` when session is dead
-- [ ] Unit tests:
-  - `TestAgentSession_StartDockerProxy_SetsProxyAddr` — start proxy, assert `GetProxyAddr()` non-empty
-  - `TestAgentSession_StartDockerProxy_AcceptsConnection` — dial the proxy addr, verify type byte written to yamux stream
-  - `TestAgentSession_Close_StopsProxyListener` — start proxy, close session, verify listener no longer accepts
-  - `TestAgentSession_StartDockerProxy_CalledTwice` — call twice; second call returns error containing "already started"; `GetProxyAddr()` returns same address as first call; no additional listener port allocated
-  - `TestOrthrusServer_HandleWebSocket_StartsProxy` — full WebSocket handshake, assert session has non-empty proxy addr
-
-**Validation gate**: `go test -race ./backend/internal/orthrus/...` passes.
-
-### Phase 3 — Backend: DockerHandler Integration
-
-**Files**: `docker_handler.go`, `routes.go`, `docker_handler_test.go`
-
-- [ ] Add `orthrusProxyResolver` interface to `docker_handler.go`
-- [ ] Add `orthrusResolver orthrusProxyResolver` field to `DockerHandler`
-- [ ] Implement `SetOrthrusResolver(r orthrusProxyResolver)`
-- [ ] Update `ListContainers`: replace single `fmt.Sprintf` with `switch server.ConnectionType`
-- [ ] In `routes.go`: hoist `var orthrusServer` declaration; call `dockerHandler.SetOrthrusResolver(orthrusServer)`
-- [ ] Unit tests:
-  - `TestDockerHandler_ListContainers_OrthrusAgentConnected` — resolver returns `("127.0.0.1:54321", true)`; verify `dockerSvc.host == "tcp://127.0.0.1:54321"`
-  - `TestDockerHandler_ListContainers_OrthrusAgentOffline` — resolver returns `("", false)`; verify 502
-  - `TestDockerHandler_ListContainers_OrthrusSubsystemUnavailable` — `orthrusResolver == nil`; verify 503
-  - `TestDockerHandler_ListContainers_OrthrusMissingAgentUUID` — server has `OrthrusAgentUUID == nil`; verify 400
-  - `TestDockerHandler_SetOrthrusResolver_Nil` — explicit nil does not panic on request
-
-**Validation gate**: `go test -race ./backend/internal/api/...` passes; no regression in existing Docker handler tests.
-
-### Phase 4 — Integration Test Stub
-
-**File**: `backend/internal/orthrus/proxy_integration_test.go`
-
-```go
-//go:build integration
-
-package orthrus_test
-
-import (
-    "testing"
-)
-
-// TestDockerProxyIntegration_FullTunnel exercises the complete path:
-//   TCP connection → local proxy listener → yamux stream → agent → Docker socket
-// Requires a running Orthrus agent with Docker socket accessible.
-func TestDockerProxyIntegration_FullTunnel(t *testing.T) {
-    t.Skip("requires running Orthrus agent with /var/run/docker.sock")
+    orthrusHandler.SetProxyResolver(orthrusServer)
 }
 ```
 
-**Validation gate**: `go test -tags integration ./backend/internal/orthrus/...` — skips cleanly.
-
-### Phase 5 — Documentation
-
-- [ ] Update `ARCHITECTURE.md` component table: add row for "Orthrus Docker Proxy Listener"
-- [ ] Confirm no OpenAPI spec changes needed (existing `GET /docker/containers` endpoint; response schema unchanged)
+No AutoMigrate change required (`OrthrusAgent` already listed).
 
 ---
 
-## 8. Acceptance Criteria
+## 7. API Endpoints
 
-| # | Criterion | Verification |
-|---|-----------|-------------|
-| AC-1 | `AgentSession.GetProxyAddr()` returns a non-empty `127.0.0.1:PORT` address after `StartDockerProxy()` succeeds | Unit test `TestAgentSession_StartDockerProxy_SetsProxyAddr` |
-| AC-2 | A TCP connection to the proxy address results in `0x01` being written to the agent's yamux stream | Unit test `TestAgentSession_StartDockerProxy_AcceptsConnection` |
-| AC-3 | Closing an `AgentSession` causes `ln.Accept()` to return an error and `runProxyListener` to exit | Unit test `TestAgentSession_Close_StopsProxyListener` |
-| AC-4 | `HandleWebSocket` registers a session with a non-zero `proxyPort` | Unit test `TestOrthrusServer_HandleWebSocket_StartsProxy` |
-| AC-5 | `GET /docker/containers?server_id=<orthrus-uuid>` with a connected agent passes `tcp://127.0.0.1:PORT` to the Docker client | Unit test `TestDockerHandler_ListContainers_OrthrusAgentConnected` |
-| AC-6 | Same request with a disconnected agent returns HTTP 502 with `"Orthrus agent is not currently connected"` | Unit test `TestDockerHandler_ListContainers_OrthrusAgentOffline` |
-| AC-7 | Same request when Orthrus subsystem is unavailable returns HTTP 503 | Unit test `TestDockerHandler_ListContainers_OrthrusSubsystemUnavailable` |
-| AC-8 | `RemoteServer` with `connection_type == "orthrus"` and nil `OrthrusAgentUUID` returns HTTP 400 | Unit test `TestDockerHandler_ListContainers_OrthrusMissingAgentUUID` |
-| AC-9 | No regression in existing Docker handler tests for direct connection type | `go test ./backend/internal/api/handlers/...` |
-| AC-10 | No regression in existing Orthrus session/server unit tests | `go test ./backend/internal/orthrus/...` |
-| AC-11 | `go test -race ./backend/...` passes with no race conditions | CI |
-| AC-12 | A second call to `StartDockerProxy()` on an already-started session returns a non-nil error containing `"already started"`. `GetProxyAddr()` still returns the address from the first successful call. No additional listener port is allocated. | `TestAgentSession_StartDockerProxy_CalledTwice` |
+### 7.1 Modified: `PATCH /api/v1/orthrus/agents/:uuid`
+
+**Auth**: Bearer (management access required)
+
+**New optional field in request body**:
+
+```json
+{ "external_proxy_port": 2375 }
+```
+
+**Validation**: `external_proxy_port` ∈ `{0} ∪ [1024, 65535]`. Values 1–1023 or > 65535 → `400 Bad Request`.
+
+**Response** `200 OK`:
+
+```json
+{
+  "uuid": "abc-123",
+  "name": "my-agent",
+  "status": "online",
+  "external_proxy_port": 2375,
+  "created_at": "...",
+  "updated_at": "..."
+}
+```
 
 ---
 
-## 9. Commit Slicing Strategy
+### 7.2 New: `GET /api/v1/orthrus/agents/:uuid/proxy-status`
 
-**Decision**: Single PR with 3 ordered logical commits. Each commit is independently compilable and testable.
+**Auth**: Bearer (management access required)
 
-**Trigger reasons**: Cross-domain change (orthrus package + handler package + routes wiring); clear phase boundary between the tunnel mechanics (Commit 1) and the HTTP handler integration (Commit 2).
+**Response** `200 OK` — agent offline, proxy disabled:
+
+```json
+{
+  "agent_uuid": "abc-123",
+  "configured_port": 0,
+  "agent_online": false,
+  "active": false,
+  "active_port": 0
+}
+```
+
+**Response** `200 OK` — agent online, proxy active:
+
+```json
+{
+  "agent_uuid": "abc-123",
+  "configured_port": 2375,
+  "agent_online": true,
+  "active": true,
+  "active_port": 2375,
+  "bind_address": "0.0.0.0:2375",
+  "connection_string": "tcp://charon:2375"
+}
+```
+
+**Response** `200 OK` — bind failed (port conflict):
+
+```json
+{
+  "agent_uuid": "abc-123",
+  "configured_port": 2375,
+  "agent_online": true,
+  "active": false,
+  "active_port": 0,
+  "error": "bind tcp 0.0.0.0:2375: bind: address already in use"
+}
+```
+
+**Error**: `404` — agent not found.
 
 ---
 
-### Commit 1 — `feat(orthrus): implement server-side Docker proxy listener`
+## 8. Frontend Changes
 
-**Scope**: Session proxy lifecycle only. No HTTP handler changes.
+### 8.1 Orthrus Agent Edit Modal — New Section
+
+**Location**: Identify the agent edit modal/panel in `frontend/src/components/orthrus/` by searching for the existing `PATCH /orthrus/agents/:uuid` call site.
+
+**New "External Docker Proxy" section**:
+
+```
+┌─ External Docker Proxy ─────────────────────────────────────────────┐
+│                                                                       │
+│  Proxy Port  [ 2375 ]   (0 = disabled · 1024–65535)                  │
+│                                                                       │
+│  ⚠ Accessible from all containers on the same Docker network.       │
+│     Do not publish this port to the host unless intended.             │
+│                                                                       │
+│  Status: ● Active   tcp://charon:2375   [Copy]                       │
+│  or:     ○ Inactive (agent offline or port=0)                        │
+│  or:     ⚠ Error: bind: address already in use                       │
+│                                                                       │
+│  ℹ Port changes take effect on next agent reconnect.                 │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+**State management**:
+
+1. On modal open: `GET /orthrus/agents/:uuid/proxy-status` → display live status.
+2. Port input: `<input type="number" min="0" max="65535" step="1">`. Client-side validation: `value === 0 || (value >= 1024 && value <= 65535)`.
+3. On save: `PATCH /orthrus/agents/:uuid` with `{ external_proxy_port: N }`.
+4. After save: re-fetch proxy status.
+
+**TypeScript type**:
+
+```typescript
+interface ExternalProxyStatus {
+  agent_uuid: string;
+  configured_port: number;
+  agent_online: boolean;
+  active: boolean;
+  active_port: number;
+  bind_address?: string;
+  connection_string?: string;
+  error?: string;
+}
+```
+
+**Accessibility** (per a11y instructions):
+
+- `<label for="external-proxy-port">` with `aria-describedby` pointing to help text.
+- `role="status"` + `aria-live="polite"` on status div.
+- Copy button: `aria-label="Copy Docker connection string to clipboard"`.
+- Bind errors: `role="alert"`.
+- Never use colour as the sole status differentiator; use icon + text.
+
+### 8.2 Agent List — Optional PROXY Badge
+
+When `external_proxy_port > 0` and agent is online: show a `PROXY` chip/badge. Clicking copies the connection string to clipboard.
+
+### 8.3 API Client
+
+Add to `frontend/src/api/orthrus.ts` (or equivalent):
+
+```typescript
+export async function getAgentProxyStatus(uuid: string): Promise<ExternalProxyStatus> {
+  const res = await api.get<ExternalProxyStatus>(`/orthrus/agents/${uuid}/proxy-status`);
+  return res.data;
+}
+```
+
+---
+
+## 9. Security Analysis
+
+### 9.1 Threat Model
+
+| Threat | Vector | Mitigation |
+|--------|--------|------------|
+| Destructive Docker control from Docker network | `POST /containers/{id}/kill` | Muzzle: only GET allowlisted paths. POST → 403. |
+| Docker API path traversal | `GET /containers/../../../etc/passwd` | Muzzle path-maps against fixed allowlist after stripping version prefix. Unmatched → 403. |
+| Log injection via path | `GET /containers%0A%0Ainjected` | `sanitizePath()` (existing in `muzzle.go`) strips `\n`/`\r`. |
+| Slowloris connection hold | Client sends partial headers | `http.Server.ReadHeaderTimeout = 10s`. |
+| SSRF via `Host` header | Attacker rewrites `Host` to internal service | `Director` unconditionally sets `req.URL.Host = "127.0.0.1:loopbackPort"`. |
+| Port pre-occupation DoS | Another process holds the port | Bind failure logged and surfaced via `/proxy-status`. Loopback proxy unaffected. No crash. |
+| Port published to Docker host | User adds `-p PORT:PORT` to Charon container | User-controlled; out of scope. UI warning displayed. |
+
+### 9.2 Residual Read Exposure
+
+Allowlisted endpoints (`/containers/json`, `/images/json`, `/info`, `/version`) reveal container names, image tags, environment variables, and network topology. Operators running sensitive workloads must evaluate whether enabling the external proxy is appropriate for their threat model.
+
+### 9.3 Defence in Depth
+
+Muzzle applied at:
+
+1. **Charon side** (new) — at the external HTTP entry point.
+2. **Agent side** (existing in `agent/leash/leash.go`) — before bytes reach the Docker socket.
+
+A bug in Charon's muzzle is not catastrophic; the agent's muzzle is a second gate.
+
+---
+
+## 10. Test Plan
+
+### 10.1 Unit Tests: `backend/internal/orthrus/session_external_proxy_test.go` (new)
+
+| ID | Description | Pass Condition |
+|----|-------------|----------------|
+| U-EXT-01 | `StartExternalProxy(0)` is a no-op | Returns nil; `GetExternalProxyStatus().Active == false` |
+| U-EXT-02 | `StartExternalProxy(PORT)` binds `0.0.0.0:PORT` | Status: `Active=true`, `BindAddress="0.0.0.0:PORT"` |
+| U-EXT-03 | Double call to `StartExternalProxy` | Second call returns error containing "already started" |
+| U-EXT-04 | `StartExternalProxy` before `StartDockerProxy` | Error contains "loopback proxy not started" |
+| U-EXT-05 | `StartExternalProxy` on closed session | Error contains "closed session" |
+| U-EXT-06 | `Close()` terminates external listener | Subsequent TCP dial refused |
+| U-EXT-07 | GET `/containers/json` through external proxy | HTTP 200 proxied through mock loopback |
+| U-EXT-08 | POST request to external proxy | HTTP 403, no yamux stream opened |
+| U-EXT-09 | GET to non-allowlisted path | HTTP 403 for `GET /exec/abc/start` |
+| U-EXT-10 | `ReadHeaderTimeout` set on http.Server | `srv.ReadHeaderTimeout == 10 * time.Second` |
+
+**Test helper**: Use `testWSPairBoth` (existing in `session_proxy_test.go`). Allocate free port with `net.Listen("tcp", "127.0.0.1:0")`, extract port, close listener, pass that port to `StartExternalProxy`.
+
+### 10.2 Unit Tests: `backend/internal/orthrus/server_test.go` (additions)
+
+| ID | Description |
+|----|-------------|
+| U-SRV-01 | `GetExternalProxyStatus` returns `(_, false)` for unknown UUID |
+| U-SRV-02 | `Close()` on session with active external proxy shuts down `http.Server` and frees the port |
+
+### 10.3 Unit Tests: `backend/internal/services/orthrus_service_test.go` (additions)
+
+| ID | Description |
+|----|-------------|
+| U-SVC-01 | `Patch` with `externalProxyPort = 0` persists successfully |
+| U-SVC-02 | `Patch` with `externalProxyPort = 2375` persists successfully |
+| U-SVC-03 | `Patch` with `externalProxyPort = 80` returns validation error |
+| U-SVC-04 | `Patch` with `externalProxyPort = 99999` returns validation error |
+| U-SVC-05 | `Patch` with `externalProxyPort = nil` leaves existing value unchanged |
+
+### 10.4 Unit Tests: `backend/internal/api/handlers/orthrus_handler_test.go` (additions)
+
+| ID | Description |
+|----|-------------|
+| U-HDL-01 | `PATCH` with `external_proxy_port: 2375` → updated agent with port |
+| U-HDL-02 | `PATCH` with `external_proxy_port: 100` → 400 |
+| U-HDL-03 | `GET /proxy-status` unknown agent → 404 |
+| U-HDL-04 | `GET /proxy-status` resolver nil → `active: false`, `error` present |
+| U-HDL-05 | `GET /proxy-status` resolver returns active status → `connection_string` present |
+| U-HDL-06 | `GET /proxy-status` resolver returns inactive status → `active: false` |
+| U-HDL-07 | `GET /proxy-status` resolver returns bind error → `error` field present |
+
+### 10.5 Playwright E2E: `tests/orthrus-external-proxy.spec.ts` (new)
+
+| Test | Steps | Expected |
+|------|-------|----------|
+| Configure proxy port | Open agent edit modal, enter 2376, save | Port saved; success toast; `/proxy-status` returns `configured_port: 2376` |
+| Disable proxy | Set port to 0, save | Status shows disabled |
+| Invalid port rejected | Enter 80, attempt save | Client-side validation error; no API call made |
+| Connection string displayed | Agent online with active proxy | `tcp://charon:2376` shown with copy button |
+| Reconnect notice | Configured port differs from active port | "Changes will take effect on next agent reconnect" message shown |
+
+### 10.6 Integration Test Stub
+
+File: `backend/internal/orthrus/external_proxy_integration_test.go`
+Build tag: `//go:build integration`
+
+Test: Full agent WebSocket connect → `ExternalProxyPort` configured → Docker client dials external port → container list returned.
+
+---
+
+## 11. Commit Slicing Strategy
+
+**Decision**: Single PR, 4 ordered logical commits. Each commit is independently buildable and passes `go test ./...`.
+
+---
+
+### Commit 1 — `feat(orthrus): add external_proxy_port field to OrthrusAgent model`
+
+**Scope**: Model only. Zero runtime behaviour change.
 
 **Files**:
-- `backend/internal/orthrus/session.go` — constant, new field, `StartDockerProxy()`, `runProxyListener()`, `proxyConn()`, updated `Close()`
-- `backend/internal/orthrus/server.go` — `StartDockerProxy()` call in `HandleWebSocket`; `sess.Close()` in `watchHeartbeat`
-- `backend/internal/orthrus/session_test.go` — 3 new tests
-- `backend/internal/orthrus/server_test.go` — 1 new test
 
-**Dependencies**: None (self-contained change to orthrus package).
+- `backend/internal/models/orthrus_agent.go` — add `ExternalProxyPort int` field
 
-**Validation gate**: `go test -race ./backend/internal/orthrus/...` — all pass.
+**Dependencies**: None.
 
-**Rollback**: Revert this commit. No other code depends on `StartDockerProxy()` until Commit 2.
+**Validation gate**:
+
+```bash
+cd backend && go build ./... && go test ./internal/models/...
+```
 
 ---
 
-### Commit 2 — `feat(docker): route orthrus-backed servers through local proxy`
+### Commit 2 — `feat(orthrus): implement external docker proxy listener with muzzle filtering`
 
-**Scope**: `DockerHandler` orthrus awareness and routes wiring.
+**Scope**: Session and server layer. New external proxy + updated `Close()` + unit tests.
 
 **Files**:
-- `backend/internal/api/handlers/docker_handler.go` — interface, field, setter, updated `ListContainers`
-- `backend/internal/api/routes/routes.go` — hoist var, call `SetOrthrusResolver`
-- `backend/internal/api/handlers/docker_handler_test.go` — 5 new tests
 
-**Dependencies**: Commit 1 (`AgentSession.GetProxyAddr()` must return a real address).
+- `backend/internal/orthrus/session.go` — `StartExternalProxy`, `GetExternalProxyStatus`, `ExternalProxyStatus` type, updated `Close()` (add `extServer.Close()`)
+- `backend/internal/orthrus/server.go` — wire `StartExternalProxy` in `HandleWebSocket`, add `GetExternalProxyStatus` method (no `watchHeartbeat` change needed — already correct)
+- `backend/internal/orthrus/session_external_proxy_test.go` — new file: U-EXT-01..10
+- `backend/internal/orthrus/server_test.go` — add U-SRV-01, U-SRV-02
 
-**Validation gate**: `go test -race ./backend/internal/api/...` — all pass; no regression in existing handler tests.
+**Dependencies**: Commit 1 (`agent.ExternalProxyPort` field must exist for `HandleWebSocket` to read).
 
-**Rollback**: Revert Commit 2. Proxy listener still runs (from Commit 1) but is never used by the Docker handler.
+**Validation gate**:
+
+```bash
+cd backend && go test ./internal/orthrus/...
+```
 
 ---
 
-### Commit 3 — `test(orthrus): add integration test stub for Docker proxy tunnel`
+### Commit 3 — `feat(orthrus): API endpoints for external proxy configuration and status`
 
-**Scope**: Integration test placeholder only.
+**Scope**: Service + handler + route wiring.
 
 **Files**:
-- `backend/internal/orthrus/proxy_integration_test.go` — `//go:build integration` stub
 
-**Dependencies**: Commits 1 and 2.
+- `backend/internal/services/orthrus_service.go` — extend `Patch`, add validation
+- `backend/internal/services/orthrus_service_test.go` — add U-SVC-01..05
+- `backend/internal/api/handlers/orthrus_handler.go` — `patchAgentRequest`, `GetProxyStatus`, `orthrusProxyStatusResolver`, `SetProxyResolver`
+- `backend/internal/api/handlers/orthrus_handler_test.go` — add U-HDL-01..07
+- `backend/internal/api/routes/routes.go` — wire `SetProxyResolver`
 
-**Validation gate**: `go test -tags integration ./backend/internal/orthrus/...` — skips cleanly.
+**Dependencies**: Commit 2 (`GetExternalProxyStatus` on `OrthrusServer`).
 
-**Rollback**: Delete the file. No functional impact.
+**Validation gate**:
+
+```bash
+cd backend && go test ./...
+```
 
 ---
 
-## 10. Security Considerations
+### Commit 4 — `feat(orthrus/ui): external docker proxy configuration and status UI`
 
-- **Loopback only**: The proxy listener binds `127.0.0.1:0` (never `0.0.0.0`). Only Charon's own process can dial it.
-- **No port reuse**: Ephemeral OS-assigned port; no hardcoded port that could be predicted or hijacked.
-- **Muzzle filter on the agent**: The agent's `handleDockerStream` applies `muzzle.Filter` (read-only Docker endpoint allowlist). Charon cannot trigger destructive Docker operations through the tunnel.
-- **Session ownership**: The `agentUUID` is authenticated by bcrypt bearer token; only a legitimate agent creates a session with its UUID.
-- **Listener closed on disconnect**: `Close()` closes the listener synchronously under the mutex. No dangling goroutine after session cleanup.
-- **No secrets in logs**: `proxyPort` (integer) and `127.0.0.1:PORT` are safe to log. No external-facing addresses exposed.
+**Scope**: Frontend only.
+
+**Files**:
+
+- `frontend/src/api/orthrus.ts` — add `getAgentProxyStatus`
+- `frontend/src/components/orthrus/<AgentEditModal>.tsx` — new External Docker Proxy section
+- `frontend/src/components/orthrus/<AgentList>.tsx` — optional PROXY badge
+- `tests/orthrus-external-proxy.spec.ts` — new Playwright E2E tests
+
+**Dependencies**: Commit 3 (API endpoints must exist).
+
+**Validation gate**:
+
+```bash
+cd frontend && npm test
+# E2E (requires Docker E2E environment rebuild):
+npx playwright test tests/orthrus-external-proxy.spec.ts --project=firefox
+```
+
+---
+
+### Rollback Notes
+
+Each commit is independently revertable:
+
+- Commit 1: DB column drop is safe (SQLite stores it; old code ignores unknown columns on read).
+- Commits 2–3: New code paths only activate when `ExternalProxyPort > 0` or the new endpoint is called. Reverting has no impact on existing agent operation.
+- Commit 4: Frontend-only; reverting does not affect backend.
+
+---
+
+## 12. Migration Strategy
+
+### 12.1 Existing agents
+
+GORM AutoMigrate at startup adds `external_proxy_port INTEGER DEFAULT 0`. All existing agents receive `0` (disabled). No proxy is started. No operator action required unless the feature is desired.
+
+### 12.2 Downgrade
+
+Old Charon without this feature ignores the unknown DB column on read. No functional breakage. The column can be dropped manually if desired.
+
+### 12.3 `socat`-based deployments (Dockhand users)
+
+Migration path:
+
+1. Identify the Orthrus agent for the target host.
+2. Set `external_proxy_port` to the port previously served by `socat` (e.g., 2375).
+3. Update Dockhand Docker host config: `tcp://socat-container:2375` → `tcp://charon:2375`.
+4. Decommission the `socat` container.
+
+The UI displays `tcp://charon:PORT` prominently once the proxy is active.
+
+### 12.4 Multi-agent port uniqueness
+
+No DB uniqueness constraint on `external_proxy_port` (excluding 0) is enforced in this PR. Operators must assign distinct ports per agent. Conflicts surface as bind errors in the `/proxy-status` endpoint. A uniqueness constraint is a future improvement.
+
+---
+
+## Appendix A: Type Placement
+
+`ExternalProxyStatus` is defined in `backend/internal/orthrus/session.go` alongside `AgentSession`. The handler imports it as `orthrus.ExternalProxyStatus` via the `orthrusProxyStatusResolver` interface. No circular imports.
+
+## Appendix B: File Change Summary
+
+| File | Change | Commit |
+|------|--------|--------|
+| `backend/internal/models/orthrus_agent.go` | Add `ExternalProxyPort int` | 1 |
+| `backend/internal/orthrus/session.go` | `StartExternalProxy`, `GetExternalProxyStatus`, `Close` update, `ExternalProxyStatus` type | 2 |
+| `backend/internal/orthrus/server.go` | Wire `StartExternalProxy`, fix `watchHeartbeat`, `GetExternalProxyStatus` | 2 |
+| `backend/internal/orthrus/session_external_proxy_test.go` | New: U-EXT-01..10 | 2 |
+| `backend/internal/orthrus/server_test.go` | Add U-SRV-01..02 | 2 |
+| `backend/internal/services/orthrus_service.go` | Extend `Patch`, add port validation | 3 |
+| `backend/internal/services/orthrus_service_test.go` | Add U-SVC-01..05 | 3 |
+| `backend/internal/api/handlers/orthrus_handler.go` | `patchAgentRequest`, `GetProxyStatus`, interface, `SetProxyResolver` | 3 |
+| `backend/internal/api/handlers/orthrus_handler_test.go` | Add U-HDL-01..07 | 3 |
+| `backend/internal/api/routes/routes.go` | Wire `SetProxyResolver` | 3 |
+| `frontend/src/api/orthrus.ts` | Add `getAgentProxyStatus` | 4 |
+| `frontend/src/components/orthrus/<modal>.tsx` | External proxy section | 4 |
+| `frontend/src/components/orthrus/<list>.tsx` | PROXY badge | 4 |
+| `tests/orthrus-external-proxy.spec.ts` | New E2E tests | 4 |

--- a/docs/plans/image-double-load-bug.md
+++ b/docs/plans/image-double-load-bug.md
@@ -86,6 +86,7 @@ const [isCollapsed, setIsCollapsed] = useState(() => {
 ```
 
 `localStorage.getItem` is synchronous. `sidebarCollapsed` is either:
+
 - `null` → defaults to `false` (banner.png rendered in sidebar)
 - `"true"` → `isCollapsed = true` (logo.png rendered in sidebar)
 - `"false"` → `isCollapsed = false` (banner.png rendered in sidebar)
@@ -180,6 +181,7 @@ When `isCollapsed = false`, the sidebar requests `/banner.png`, and the mobile h
 boundary should only wrap the content area (`<Outlet>`), not the shell.
 
 **Before** (`App.tsx`):
+
 ```tsx
 <Suspense fallback={<LoadingOverlay message="Loading application..." />}>
   <Routes>
@@ -195,6 +197,7 @@ boundary should only wrap the content area (`<Outlet>`), not the shell.
 ```
 
 **After** (`App.tsx`):
+
 ```tsx
 {/* No Suspense wrapper at Routes level — only wraps unauthenticated lazy pages */}
 <Routes>
@@ -230,6 +233,7 @@ boundary should only wrap the content area (`<Outlet>`), not the shell.
 ```
 
 **And** inside `Layout.tsx`, wrap children rendering:
+
 ```tsx
 {/* ✅ Suspense only wraps the content area; sidebar/header stay mounted */}
 <Suspense fallback={<PageLoadingFallback />}>
@@ -248,6 +252,7 @@ image on desktop screens, eliminating the invisible network request.
 Two acceptable implementation options:
 
 **Option A — `useMediaQuery` hook (preferred for testability)**:
+
 ```tsx
 // frontend/src/hooks/useMediaQuery.ts (new file)
 export function useMediaQuery(query: string): boolean {
@@ -273,6 +278,7 @@ const isMobile = useMediaQuery('(max-width: 1023px)')   // < lg breakpoint
 ```
 
 **Option B — `loading="lazy"` + `decoding="async"` (simpler, CSS-safe)**:
+
 ```tsx
 <img
   src="/logo.png"

--- a/docs/reports/qa_report.md
+++ b/docs/reports/qa_report.md
@@ -1,330 +1,84 @@
-# QA & Security Audit — CI Fix Implementation
-
-| Field       | Value                                         |
-|-------------|-----------------------------------------------|
-| Date        | 2026-05-13                                    |
-| Branch      | `development`                                 |
-| HEAD commit | `6b4c5d50`                                    |
-| Auditor     | QA Security Agent                             |
-| Verdict     | ✅ **APPROVED**                               |
-
----
-
-## Summary
-
-Full QA and security audit performed after the CI fix implementation. All 8 checks
-passed. No blocking issues found. One Trivy HIGH finding reviewed and confirmed as
-an expected local development artifact (not committed to VCS).
-
----
-
-## Check Results
-
-| # | Check                          | Result      | Notes                                  |
-|---|--------------------------------|-------------|----------------------------------------|
-| 1 | Frontend Tests + Coverage      | ✅ PASS      | 481 pass, 1 skip; coverage 89.33%      |
-| 2 | TypeScript Type Check          | ✅ PASS      | 0 errors                               |
-| 3 | Frontend ESLint                | ✅ PASS      | 0 errors, 994 warnings (exit 0)        |
-| 4 | Backend Tests + Coverage       | ✅ PASS      | All tests pass; coverage 88.5%/88.6%   |
-| 5 | Backend Lint (golangci-lint)   | ✅ PASS      | 0 issues                               |
-| 6 | Pre-commit Hooks (lefthook)    | ✅ PASS      | All applicable hooks pass              |
-| 7 | Race Condition Verification    | ✅ PASS      | 5/5 runs with `-race` flag pass        |
-| 8 | Trivy Security Scan            | ✅ PASS*     | 1 HIGH finding reviewed (see below)    |
-| - | GORM Security Scan             | ⏭ SKIP      | No model/DB files changed              |
-
----
-
-## Coverage
-
-| Layer    | Statement | Line  | Threshold | Status  |
-|----------|-----------|-------|-----------|---------|
-| Frontend | 89.33%    | —     | 87%       | ✅ PASS |
-| Backend  | 88.5%     | 88.6% | 87%       | ✅ PASS |
-
----
-
-## Security Findings
-
-### Trivy Scan
-
-**Scanners**: `vuln`, `secret`
-**Severity filter**: HIGH, CRITICAL
-
-| Severity | Type   | Target                                          | Rule                  | Status        |
-|----------|--------|-------------------------------------------------|-----------------------|---------------|
-| HIGH     | Secret | `backend/internal/api/routes/keys/hecate-ca.key` | AsymmetricPrivateKey | ✅ REVIEWED   |
-
-**Vulnerability findings**: 0 (Go modules, npm packages all clean)
-
-#### Trivy HIGH Finding — `hecate-ca.key`
-
-Trivy flagged a local EC private key file (`backend/internal/api/routes/keys/hecate-ca.key`)
-as HIGH severity (AsymmetricPrivateKey).
-
-**Investigation result**: This is an **expected local development artifact**. The finding
-does **not** represent a committed secret.
-
-- `.gitignore` line 146 contains the pattern `*.key`, which excludes all `.key` files
-  from version control. `git check-ignore` confirms the file is ignored.
-- `git ls-files backend/internal/api/routes/keys/` shows only `hecate-ca.crt` is tracked;
-  the `.key` file is **not** in the repository.
-- The key is the Hecate CA private key, generated locally by the Orthrus CA module
-  (`backend/internal/orthrus/ca.go`). It is generated on first use and stored locally
-  by design — it is never committed.
-- The companion certificate (`hecate-ca.crt`) is tracked (it is a public artifact).
-
-**Conclusion**: Not a committed secret. Gitignore coverage is correct. No remediation
-required.
-
----
-
-## CI Fixes Audited
-
-The following files were created or modified as part of the CI fix implementation
-covered by this audit:
-
-| File                                                                 | Change                              |
-|----------------------------------------------------------------------|-------------------------------------|
-| `frontend/package.json`                                              | Removed duplicate devDependencies   |
-| `frontend/src/utils/certificateUtils.ts`                             | New utility extracted from component|
-| `frontend/src/components/CertificateList.tsx`                        | Import path + exports updated        |
-| `frontend/src/components/__tests__/CertificateList.test.tsx`         | Import path updated                  |
-| `frontend/src/components/CSPBuilder.tsx`                             | `<label>` → `<span>` (HTML fix)     |
-| `frontend/src/components/AccessListSelector.tsx`                     | `<label>` → `<span>` (HTML fix)     |
-| `frontend/src/components/AccessListForm.tsx`                         | `<label>` → `<span>` (HTML fix)     |
-| `frontend/src/components/CredentialManager.tsx`                      | eslint-disable comment added         |
-| `frontend/src/api/__tests__/logs-websocket.test.ts`                  | `.skip` → `.todo` (2 tests)          |
-| `backend/internal/api/handlers/security_handler.go`                  | `Close()` method added               |
-| `backend/internal/api/handlers/security_handler_audit_test.go`       | Test isolation via `t.Cleanup`       |
-| `backend/internal/hecate/providers/cloudflare/provider.go`           | WaitGroup race condition fixed       |
-
----
-
-## Notable Observations
-
-- **ESLint warnings (994)**: All warnings, zero errors. Pre-existing state; not introduced
-  by the CI fix implementation. No action required for this audit.
-- **Low-coverage files** (informational, not blocking):
-  - `src/api/crowdsecDashboard.ts` — 0%
-  - `src/pages/HecateAgent.tsx` — 44.44%
-  - `src/pages/HecateTunnels.tsx` — 49.30%
-  - `src/hooks/useFocusTrap.ts` — 47.83%
-- **Race condition fix verified**: `TestStart_CapturesStdoutOutput` with `-race -count=5`
-  passed 5/5 runs after the WaitGroup fix in `cloudflare/provider.go`.
-- **`security_handler.go` resource cleanup**: `Close()` method and `t.Cleanup` in
-  all 15 test functions eliminates goroutine/handler leaks in tests.
-
----
-
-## Verdict
-
-**✅ APPROVED**
-
-All 8 checks pass. Coverage is above the 87% threshold for both frontend and backend.
-The single Trivy HIGH finding is a local development artifact correctly excluded from
-VCS by `.gitignore`. No blocking issues found.
-
----
-
-<!-- Previous report archived below — Hecate Provider Integration (2026-04-30) -->
+# QA Report — Orthrus External Docker Proxy
+**Date**: 2026-05-20
+**Feature**: External Docker Proxy (Orthrus)
+**Branch**: feature/hecate
 
 ## Gate Results
 
-### Gate 1 — Backend Unit Tests (`go test ./...`)
+| Gate | Description | Result | Notes |
+|------|-------------|--------|-------|
+| 0 | E2E Container Rebuild | ✅ | `charon-e2e` Up healthy; ports 8080/2020/2019 confirmed |
+| 1 | Playwright E2E | ❌ | Infrastructure blocker: ubuntu26.04-x64 not supported by Playwright 1.60.0; all install methods exhausted; CI environment (ubuntu-latest) is unaffected |
+| 2 | Backend Unit Coverage | ✅ | 89.0% (threshold: 85%); `backend/coverage.txt` generated 2026-05-20 |
+| 3 | Frontend Unit Coverage | ✅ | 89.4% (threshold: 85%); `frontend/coverage/lcov.info` valid |
+| 4 | Local Patch Report | ⚠️ | 86.9% (threshold: 90%, mode=warn, exit 0); uncovered changed lines: `server.go` L97-99 (40%), `session.go` L127-128, 160-161, 167-170, 210-212 (84.9%) |
+| 5 | TypeScript Type-check | ✅ | `npm run type-check` exit 0 |
+| 6 | Lefthook Equivalent | ✅ | `go vet ./...` exit 0; ESLint 0 errors (993 pre-existing warnings) |
+| 7 | GORM Security Scan | ✅ | 0 CRITICAL, 0 HIGH; 2 pre-existing INFO items (UserID/ProxyHostID FK index in `models/user.go:130-131`) |
+| 8 | Trivy FS Scan | ✅ | Exit 0; no CRITICAL/HIGH; DB updated 2026-05-20T05:16:05Z |
+| 9 | Docker Image Scan | ❌ | 3 HIGH findings in bundled binaries (Caddy, CrowdSec); no CRITICAL; see Security Findings |
 
-| Status | Exit Code |
-|--------|-----------|
-| ✅ PASS | 0         |
+## Coverage Summary
 
-All 36 Go packages pass. Hecate-specific packages:
+- Backend: 89.0%
+- Frontend: 89.4%
+- Patch coverage: 86.9% (threshold: 90%, mode: warn)
 
-| Package                                         | Result |
-|-------------------------------------------------|--------|
-| `internal/hecate`                               | PASS   |
-| `internal/hecate/providers/cloudflare`          | PASS   |
-| `internal/hecate/providers/netbird`             | PASS   |
-| `internal/hecate/providers/tailscale`           | PASS   |
-| `internal/hecate/providers/zerotier`            | PASS   |
-| `internal/orthrus`                              | PASS   |
+### Patch Coverage Detail
 
-`go vet ./...` also exits 0 with no diagnostics.
+| File | Patch Coverage | Uncovered Changed Lines |
+|------|---------------|------------------------|
+| `backend/internal/orthrus/server.go` | 40.0% | 97–99 |
+| `backend/internal/orthrus/session.go` | 84.9% | 127–128, 160–161, 167–170, 210–212 |
+| `frontend/src/` (changed files) | 100.0% | — |
 
----
+## Security Findings
 
-### Gate 2 — TypeScript Type-Check (`tsc --noEmit`)
+### Gate 7 — GORM Security Scan (PASSED)
 
-| Status | Exit Code |
-|--------|-----------|
-| ✅ PASS | 0         |
+No CRITICAL or HIGH issues. Two pre-existing INFO items that are non-blocking:
+- `backend/internal/models/user.go:130-131` — UserID/ProxyHostID foreign key index (INFO, pre-existing)
 
-No type errors detected across the entire frontend source.
+### Gate 8 — Trivy Filesystem Scan (PASSED)
 
----
+No CRITICAL or HIGH vulnerabilities in the filesystem. Trivy DB freshly updated 2026-05-20T05:16:05Z.
 
-### Gate 3 — Frontend Coverage (`vitest run --coverage`)
+### Gate 9 — Docker Image Scan (FAILED)
 
-| Metric      | Coverage  | Threshold | Status    |
-|-------------|-----------|-----------|-----------|
-| Lines       | **90.35%** | 85%      | ✅ PASS   |
-| Functions   | **86.76%** | 85%      | ✅ PASS   |
-| Branches    | **82.18%** | N/A      | ✅ INFO   |
-| Statements  | **89.41%** | 85%      | ✅ PASS   |
+Three HIGH vulnerabilities found in bundled third-party binaries. No CRITICAL findings.
 
-**Hecate/Orthrus file coverage:**
+#### CVE-2026-45135 — `github.com/caddyserver/caddy/v2` (HIGH)
 
-| File                                        | Lines  | Functions |
-|---------------------------------------------|--------|-----------|
-| `api/hecate.ts`                             | 96.49% | 94.73%    |
-| `api/orthrus.ts`                            | 100%   | 100%      |
-| `components/hecate/CloudflareTunnelWizard`  | 97.29% | 91.66%    |
-| `components/hecate/ConnectionTypeSelector`  | 100%   | 100%      |
-| `components/hecate/OrthrusInstallWizard`    | 95.83% | 70%       |
-| `components/hecate/TunnelLogViewer`         | 89.28% | 75%       |
-| `components/hecate/TunnelStatusBadge`       | 100%   | 100%      |
-| `hooks/useHecate.ts`                        | 100%   | 100%      |
-| `hooks/useOrthrus.ts`                       | 100%   | 100%      |
+- **Binary**: `/usr/bin/caddy`
+- **Installed**: v2.11.2
+- **Fixed**: v2.11.3
+- **Status**: Fix available — upgrade required
+- **Description**: Unsafe Unicode handling in FastCGI `splitPos` allows execution of non-PHP files
+- **Reference**: https://avd.aquasec.com/nvd/cve-2026-45135
+- **Remediation**: Update Caddy build version in `Dockerfile` from v2.11.2 to v2.11.3
 
-All Hecate-related files are above threshold. Lower function coverage in
-`OrthrusInstallWizard` (70%) and `TunnelLogViewer` (75%) reflects edge-case
-render branches that require full integration to trigger.
+#### CVE-2026-32286 — `github.com/jackc/pgproto3/v2` in CrowdSec (HIGH)
 
----
+- **Binaries**: `/usr/local/bin/crowdsec`, `/usr/local/bin/cscli`
+- **Installed**: v2.3.3
+- **Fixed**: No upstream fix available at time of scan
+- **Status**: Affected; awaiting upstream patch in CrowdSec
+- **Description**: Denial of Service via malicious PostgreSQL server response
+- **Reference**: https://avd.aquasec.com/nvd/cve-2026-32286
+- **Risk Context**: Exploitable only when CrowdSec is configured to use a PostgreSQL backend. The default Charon deployment uses the local SQLite backend; PostgreSQL is not used. Risk is LOW in standard deployments.
+- **Remediation**: Track upstream CrowdSec release that patches pgproto3/v2; no immediate action available
 
-### Gate 4 — ESLint (`eslint src/`)
+### Pre-existing Backend Test Failure (Not Orthrus-related)
 
-| Status                 | Exit Code | Notes                                      |
-|------------------------|-----------|--------------------------------------------|
-| ✅ PASS (after fix)    | 0         | 1 error fixed; 978 pre-existing warnings   |
+- `TestSendExternal_AllEventTypes/domain` (notification/webhook tests) — pre-existing failure unrelated to this feature; does not affect Gate 2 result.
 
-**Finding:** `frontend/src/locales/en/translation.json` contained a duplicate
-`"form"` key at line 1700, identical to the one already defined at line 1621
-within the `"hecate"` namespace.
+## Conclusion
 
-```
-1700:5  error  Duplicate key "form" found  json/no-duplicate-keys
-```
+**BLOCKED** — Gate 9 failed due to HIGH severity CVEs in bundled third-party binaries.
 
-**Fix applied:** Removed the duplicate `"form"` block (lines 1700–1722) from
-`translation.json`. ESLint re-run exits 0 with no errors.
+### Required Actions Before Approval
 
-**Warnings (978):** All pre-existing. No new warnings introduced by the
-Hecate integration. Non-blocking.
-
----
-
-### Gate 5 — Hook Runner (`lefthook run pre-commit`)
-
-| Status  | Exit Code | Notes                                          |
-|---------|-----------|------------------------------------------------|
-| ✅ N/A  | 0         | All hooks skipped (no staged files)            |
-
-The project migrated from `pre-commit` to `lefthook`. There is no
-`.pre-commit-config.yaml`. Running `pre-commit run --all-files` fails with
-`InvalidConfigError`. The equivalent `lefthook run pre-commit` exits 0 but
-skips all hooks when no files are staged. Static analysis and linting are
-covered by Gates 1–4 and Gate 6.
-
----
-
-### Gate 6 — GORM Security Scan (`scan-gorm-security.sh --check`)
-
-| Status  | Exit Code |
-|---------|-----------|
-| ✅ PASS | 0         |
-
-| Severity | Count |
-|----------|-------|
-| CRITICAL | 0     |
-| HIGH     | 0     |
-| MEDIUM   | 0     |
-| INFO     | 2     |
-
-**INFO findings (non-blocking):**
-
-| File                               | Lines   | Finding                                                              |
-|------------------------------------|---------|----------------------------------------------------------------------|
-| `backend/internal/models/user.go`  | 130–131 | Missing `gorm:"index"` on `UserID` and `ProxyHostID` FK columns in `UserPermittedHost` |
-
-These are performance suggestions, not security issues. No blocking findings.
-
----
-
-### Gate 7 — Local Patch Coverage Report
-
-| Status  | Exit Code |
-|---------|-----------|
-| ✅ PASS | 0         |
-
-| Scope    | Changed Lines | Covered Lines | Patch Coverage | Threshold | Status    |
-|----------|---------------|---------------|----------------|-----------|-----------|
-| Overall  | 2401          | 2165          | **90.2%**      | 90.0%     | ✅ PASS   |
-| Backend  | 2111          | 1890          | **89.5%**      | 85.0%     | ✅ PASS   |
-| Frontend | 290           | 275           | **94.8%**      | 85.0%     | ✅ PASS   |
-
-**Files below 90% patch coverage** (warning, non-blocking at current thresholds):
-
-| File                                                         | Patch % | Uncovered Lines | Notes                           |
-|--------------------------------------------------------------|---------|-----------------|--------------------------------|
-| `backend/cmd/api/main.go`                                    | 0.0%    | 2 (263–264)     | Pre-existing; main() untestable |
-| `backend/internal/services/crowdsec_startup.go`              | 0.0%    | 3               | Pre-existing startup code       |
-| `backend/internal/services/dns_provider_service.go`          | 0.0%    | 2               | Pre-existing                    |
-| `backend/internal/services/plugin_loader.go`                 | 11.1%   | 8               | Pre-existing                    |
-| `frontend/src/components/RemoteServerForm.tsx`               | 80.8%   | 5 (216–231)     | Hecate agent-mode conditionals  |
-| `backend/internal/hecate/providers/tailscale/api_client.go`  | 81.0%   | 11              | HTTP error paths                |
-| `backend/internal/api/routes/routes.go`                      | 82.1%   | 7 (466–479)     | Hecate route registrations      |
-| `backend/internal/api/handlers/hecate_ws_handler.go`         | 82.8%   | 11              | WebSocket upgrade/error paths   |
-| `backend/internal/orthrus/session.go`                        | 84.6%   | 12              | TLS session setup error paths   |
-| `backend/internal/hecate/manager.go`                         | 84.9%   | 33 (285–322)    | Provider start/stop error paths |
-
-All uncovered lines in Hecate code are error-handling branches. Core logic
-paths are covered. The 0% entries are pre-existing gaps unrelated to this
-feature.
-
-Full artifacts: `test-results/local-patch-report.md`, `test-results/local-patch-report.json`
-
----
-
-## Summary of Fixes Applied
-
-| # | File                                            | Issue                                 | Fix                                    |
-|---|-------------------------------------------------|---------------------------------------|----------------------------------------|
-| 1 | `frontend/src/locales/en/translation.json:1700` | Duplicate `"form"` key (ESLint error) | Removed duplicate block (lines 1700–1722) |
-
----
-
-## Blocking Issues
-
-None.
-
----
-
-## Non-Blocking Observations
-
-1. **`TunnelLogViewer.tsx` function coverage (75%)** — Uncovered render branches
-   require specific WebSocket error states. Consider adding targeted tests in a
-   follow-up.
-
-2. **`hecate/manager.go` patch coverage (84.9%)** — Lines 285–322 are provider
-   lifecycle error paths that require mock provider injection. Track as tech
-   debt.
-
-3. **`orthrus/session.go` patch coverage (84.6%)** — TLS session establishment
-   error paths require a full PKI mock to cover. Non-blocking.
-
-4. **GORM index suggestion (`user.go:130–131`)** — Adding `gorm:"index"` to
-   `UserPermittedHost.UserID` and `UserPermittedHost.ProxyHostID` would improve
-   query performance. Recommended as a follow-up.
-
----
-
-## Final Verdict
-
-**✅ PASS** — All mandatory gates pass. One ESLint error was fixed during audit
-(duplicate JSON key in `translation.json`). No security vulnerabilities
-detected. Patch coverage meets all configured thresholds (90.2% overall vs
-90.0% required). The Hecate Provider Integration is ready for merge to
-`development`.
-
----
-
-*Report generated by QA Security Agent — 2026-04-30 (HEAD `26fc4a1a`)*
+1. **Gate 9 — Caddy CVE-2026-45135** (blocking): Upgrade Caddy from v2.11.2 to v2.11.3 in the Dockerfile. A fix is available.
+2. **Gate 9 — pgproto3 CVE-2026-32286** (conditional): No upstream fix exists yet. Document as accepted risk given Charon's default non-PostgreSQL CrowdSec configuration, or pin for remediation when CrowdSec releases a patched version.
+3. **Gate 1 — Playwright E2E** (infrastructure): Local environment is blocked by ubuntu26.04-x64 incompatibility with Playwright 1.60.0. CI (ubuntu-latest) runs these tests successfully. This gate should be confirmed passing via CI before merge.
+4. **Gate 4 — Patch Coverage** (advisory): 86.9% is below the 90% threshold. Uncovered lines in `server.go` (L97–99) and `session.go` (L127–128, 160–161, 167–170, 210–212) should receive targeted tests to close the gap.

--- a/docs/reports/qa_report_pr1031_hecate_external_proxy.md
+++ b/docs/reports/qa_report_pr1031_hecate_external_proxy.md
@@ -1,0 +1,426 @@
+# QA Audit Report — PR #1031: External Docker Proxy (feature/hecate)
+
+| Field           | Value                                    |
+|-----------------|------------------------------------------|
+| **PR**          | #1031                                    |
+| **Branch**      | `feature/hecate`                         |
+| **Audit Date**  | 2026-05-20                               |
+| **Auditor**     | QA Security (automated)                  |
+| **Feature**     | External Docker Proxy (Orthrus subsystem)|
+| **Verdict**     | **BLOCKED — Required fixes before merge**|
+
+---
+
+## Audit Summary
+
+PR #1031 introduces the External Docker Proxy feature to the Orthrus agent subsystem. It adds
+TCP port forwarding through the yamux session layer, a new frontend configuration dialog in
+`OrthrusAgentManager`, and badge rendering for proxy-enabled agents.
+
+**Overall verdict: BLOCKED.** Gates 1 and 6 fail on PR-scope code. Gate 9 has an actionable
+HIGH CVE (Caddy v2.11.2 in the stale local image; the Dockerfile already pins the fix at
+v2.11.3 — a rebuild is required). Six required fixes are enumerated in
+[Required Actions](#required-actions).
+
+---
+
+## Gate Results
+
+| Gate | Name                       | Result             | Threshold            |
+|------|----------------------------|--------------------|----------------------|
+| 1    | E2E Playwright             | **FAIL**           | All tests pass       |
+| 2    | Backend Unit Coverage      | **PASS**           | 85% (≥91.2%)         |
+| 3    | Frontend Unit Coverage     | **PASS**           | 87% lines (≥89.35%)  |
+| 4    | Local Patch Coverage       | **WARN**           | 85% back (82.9%)     |
+| 5    | TypeScript Type-check      | **PASS**           | Zero errors          |
+| 6    | Lint (lefthook lint-full)  | **FAIL**           | Zero issues (3 found)|
+| 7    | GORM Security Scan         | **PASS**           | 0 CRITICAL/HIGH      |
+| 8    | Trivy Filesystem Scan      | **PASS**           | 0 CRITICAL/HIGH      |
+| 9    | Trivy Image Scan           | **WARN**           | 0 CRITICAL (1 fixable HIGH via rebuild) |
+
+---
+
+## Gate 1 — E2E Playwright
+
+**Result: FAIL**
+**Duration:** 41.1 s · Tests passed: 2/9 · Tests failed: 7/9
+
+### Passing tests
+- `auth setup` — session file written
+- `PROXY badge appears in agent row when external_proxy_port > 0`
+
+### Failing tests (6) — Root Cause 1: Missing i18n key
+
+All calls to `openProxyDialog()` in `tests/orthrus-external-proxy.spec.ts` (line 88) match
+the button by regex `Configure external proxy`. At runtime `aria-label` resolves to the raw
+i18n key string `hecate.agentManager.configureProxy` because the key does not exist in any of
+the five locale files. The regex never matches, the locator times out, and six tests abort.
+
+**Affected tests:**
+- `opens the proxy configuration dialog`
+- `shows validation error when port is invalid`
+- `saves proxy configuration successfully`
+- `clears proxy configuration`
+- `disables save button when proxy port is empty`
+- `shows loading state while saving`
+
+**Root cause:** `frontend/src/components/hecate/OrthrusAgentManager.tsx` line 177:
+
+```tsx
+aria-label={t('hecate.agentManager.configureProxy', { name: agent.name })}
+```
+
+The key `configureProxy` is absent from all five locale files:
+`frontend/src/locales/{en,es,fr,de,zh}/translation.json`
+
+**Fix required:** Add the key to every locale file (see [Required Actions](#required-actions)).
+
+### Failing test (1) — Root Cause 2: Strict-mode locator violation
+
+`tests/orthrus-external-proxy.spec.ts` line 283:
+
+```ts
+const proxyBadge = page.getByText('PROXY');
+```
+
+The locator resolves to two elements (badge text + heading text), triggering Playwright strict
+mode. The test throws `Error: strict mode violation`.
+
+**Fix required:** Add `{ exact: true }` to the locator (see [Required Actions](#required-actions)).
+
+---
+
+## Gate 2 — Backend Unit Coverage
+
+**Result: PASS**
+**Coverage:** 91.2% (threshold: 85%)
+**Artifact:** `backend/coverage.txt`
+
+All backend packages pass. No action required.
+
+---
+
+## Gate 3 — Frontend Unit Coverage
+
+**Result: PASS**
+**Coverage (lines):** 89.35% (threshold: 87%)
+**Artifact:** `frontend/coverage/lcov.info`
+
+| Metric     | Value  | Threshold |
+|------------|--------|-----------|
+| Lines      | 89.35% | 87%       |
+| Statements | 88.37% | —         |
+| Functions  | 85.43% | —         |
+| Branches   | 81.55% | —         |
+
+---
+
+## Gate 4 — Local Patch Coverage
+
+**Result: WARN (non-blocking, mode=warn)**
+**Generated:** 2026-05-20T10:16:33Z
+**Artifacts:** `test-results/local-patch-report.md`, `test-results/local-patch-report.json`
+
+| Scope    | Changed Lines | Covered Lines | Patch Coverage | Threshold | Status |
+|----------|---------------|---------------|----------------|-----------|--------|
+| Overall  | 111           | 92            | 82.9%          | 90.0%     | warn   |
+| Backend  | 111           | 92            | 82.9%          | 85.0%     | warn   |
+| Frontend | 0             | 0             | 100.0%         | 85.0%     | pass   |
+
+### Files needing coverage
+
+| File                                          | Patch Coverage | Uncovered Lines         |
+|-----------------------------------------------|----------------|-------------------------|
+| `backend/internal/orthrus/server.go`          | 60.0%          | 96–97                   |
+| `backend/internal/orthrus/session.go`         | 77.9%          | 127–128, 160–161, 167–175, 199–203 |
+
+**`server.go` lines 96–97:** Error logging path inside
+`if err := session.StartDockerProxy(); err != nil`. Error path not exercised by existing tests.
+
+**`session.go` uncovered paths:** yamux error path in `NewAgentSession` (127–128), double-check
+pattern for closed-session in `StartDockerProxy` (160–161, 167–175), and transient retry logic
+in `runProxyListener` (199–203).
+
+Patch coverage is non-blocking (mode=warn) but is below both thresholds. Adding targeted error
+path tests is strongly recommended before merge.
+
+---
+
+## Gate 5 — TypeScript Type-check
+
+**Result: PASS**
+Zero type errors across the entire frontend. `tsc --noEmit` succeeded.
+
+---
+
+## Gate 6 — Lint (lefthook lint-full)
+
+**Result: FAIL**
+
+### golangci-lint — PR-scope issues (3)
+
+| File                                                        | Line | Linter    | Issue                                                   |
+|-------------------------------------------------------------|------|-----------|---------------------------------------------------------|
+| `backend/internal/orthrus/session.go`                       | 237  | gosec     | G104: Errors unhandled — `io.Copy` (nolint present for errcheck only) |
+| `backend/internal/orthrus/session.go`                       | 242  | gosec     | G104: Errors unhandled — `io.Copy` (nolint present for errcheck only) |
+| `backend/internal/orthrus/session_external_proxy_test.go`   | 62   | errcheck  | Error return of `conn.Close()` not checked in `defer`   |
+| `backend/internal/orthrus/session_proxy_test.go`            | 19   | gocritic  | `paramTypeCombine` — two adjacent `*websocket.Conn` params can be combined |
+
+> Note: `session.go` lines 237 and 242 carry `//nolint:errcheck` but gosec G104 is not
+> suppressed. The directive must become `//nolint:errcheck,gosec`.
+
+### hadolint — Dockerfile (7 info-level, non-blocking)
+
+All findings are `DL3059` (consecutive `RUN` instructions) or `SC2012` (use `find` instead of
+`ls`). Severity: info. No warnings or errors. Non-blocking.
+
+### markdownlint — Auto-generated artifacts (non-blocking)
+
+Lint ran on files under `test-results/` and `docs/reports/` that are generated artifacts.
+Non-blocking.
+
+---
+
+## Gate 7 — GORM Security Scan
+
+**Result: PASS**
+Zero findings across all severity levels (CRITICAL, HIGH, MEDIUM, LOW).
+
+The `external_proxy_port` field added to `backend/internal/models/orthrus_agent.go` is a
+non-sensitive integer with `gorm:"default:0"`. `ID` is correctly `json:"-"`.
+`AuthKeyHash` is correctly `json:"-"`. No data exposure risk detected.
+
+---
+
+## Gate 8 — Trivy Filesystem Scan
+
+**Result: PASS**
+Zero CRITICAL or HIGH findings in project source dependencies (`backend/go.sum`, `package.json`).
+
+All CRITICAL/HIGH findings reported by Trivy were confined to `.cache/go/pkg/mod/` (developer
+tool cache). These packages are not shipped in the production image and do not constitute a
+vulnerability in the distributed artifact.
+
+---
+
+## Gate 9 — Trivy Image Scan
+
+**Result: WARN — 0 CRITICAL, 3 HIGH (2 unique CVEs)**
+**Scan target:** `charon:local` (image tar via `docker save`)
+
+| CVE               | Component                    | Version   | CVSS | Fixed In | Status       |
+|-------------------|------------------------------|-----------|------|----------|--------------|
+| CVE-2026-45135    | `github.com/caddyserver/caddy/v2` | 2.11.2 | 8.1 | 2.11.3   | **Dockerfile already updated — rebuild required** |
+| CVE-2026-32286    | `github.com/jackc/pgproto3/v2`   | 2.3.3  | 7.5 | None     | Pre-existing, no fix available |
+
+### CVE-2026-45135 (HIGH · CVSS 8.1)
+
+- **Component:** Caddy v2.11.2 (embedded in Charon binary via xcaddy)
+- **Description:** Unsafe Unicode handling in FastCGI `splitPos` function. Network-reachable
+  (AV:N), high complexity (AC:H), no privileges required. Potential for confidentiality and
+  integrity impact.
+- **Affects:** Any Charon deployment using the FastCGI reverse proxy capability.
+- **Fix available:** v2.11.3
+- **Status:** The Dockerfile `ARG CADDY_VERSION` is **already pinned to 2.11.3**. The
+  `charon:local` image is a stale build from before this change. A container image rebuild
+  will apply the fix.
+- **Action required:** Rebuild the container image before publishing/deploying.
+
+### CVE-2026-32286 (HIGH · CVSS 7.5)
+
+- **Component:** `github.com/jackc/pgproto3/v2` v2.3.3
+- **Description:** DoS via malicious PostgreSQL server sending a DataRow message with a
+  negative field length in `DataRow.Decode`. AV:N, AC:L, no privileges required.
+- **Fix available:** None (upstream unresolved)
+- **Pre-existing:** This CVE predates PR #1031 and is not introduced by this change.
+- **Action required:** Document in `SECURITY.md` (see [SECURITY.md Updates](#securitymd-updates)).
+
+---
+
+## Required Actions
+
+The following issues **must** be resolved before merging PR #1031.
+
+### Fix 1 — Add missing i18n translation key (BLOCKS Gate 1)
+
+Add `configureProxy` to the `hecate.agentManager` section in all five locale files:
+
+**`frontend/src/locales/en/translation.json`**
+```json
+"configureProxy": "Configure external proxy for {{name}}"
+```
+
+**`frontend/src/locales/es/translation.json`**
+```json
+"configureProxy": "Configurar proxy externo para {{name}}"
+```
+
+**`frontend/src/locales/fr/translation.json`**
+```json
+"configureProxy": "Configurer le proxy externe pour {{name}}"
+```
+
+**`frontend/src/locales/de/translation.json`**
+```json
+"configureProxy": "Externen Proxy für {{name}} konfigurieren"
+```
+
+**`frontend/src/locales/zh/translation.json`**
+```json
+"configureProxy": "为 {{name}} 配置外部代理"
+```
+
+### Fix 2 — Resolve Playwright strict-mode violation (BLOCKS Gate 1)
+
+**`tests/orthrus-external-proxy.spec.ts` line 283:**
+
+```ts
+// Before
+const proxyBadge = page.getByText('PROXY');
+
+// After
+const proxyBadge = page.getByText('PROXY', { exact: true });
+```
+
+### Fix 3 — Suppress gosec G104 in nolint directives (BLOCKS Gate 6)
+
+**`backend/internal/orthrus/session.go` lines 237 and 242:**
+
+```go
+// Before
+_, _ = io.Copy(dst, src) //nolint:errcheck
+
+// After
+_, _ = io.Copy(dst, src) //nolint:errcheck,gosec
+```
+
+### Fix 4 — Suppress errcheck on deferred close in test (BLOCKS Gate 6)
+
+**`backend/internal/orthrus/session_external_proxy_test.go` line 62:**
+
+```go
+// Before
+defer conn.Close()
+
+// After
+defer conn.Close() //nolint:errcheck
+```
+
+### Fix 5 — Combine websocket.Conn parameter types (BLOCKS Gate 6)
+
+**`backend/internal/orthrus/session_proxy_test.go` line 19** — combine adjacent
+`*websocket.Conn` parameters per gocritic `paramTypeCombine`:
+
+```go
+// Before
+func proxyHelper(c1 *websocket.Conn, c2 *websocket.Conn) { ... }
+
+// After
+func proxyHelper(c1, c2 *websocket.Conn) { ... }
+```
+
+*(Adjust function signature to match actual source; the pattern is the same.)*
+
+### Fix 6 — Rebuild container image to apply Caddy 2.11.3 (BLOCKS Gate 9 for deployment)
+
+The Dockerfile already specifies `ARG CADDY_VERSION=2.11.3`. The `charon:local` image is
+a stale build. Rebuild before publishing or deploying:
+
+```bash
+.github/skills/scripts/skill-runner.sh docker-rebuild-e2e
+```
+
+Or the standard Docker build process for the release image.
+
+---
+
+## Recommended Actions
+
+The following issues are non-blocking but are strongly recommended before merge.
+
+### Recommendation 1 — Increase patch coverage for error paths
+
+`backend/internal/orthrus/server.go` (60.0% patch) and `session.go` (77.9% patch) have
+uncovered error paths in PR-scope code. Adding targeted unit tests for these paths would:
+
+- Bring backend patch coverage above the 85% threshold
+- Ensure error propagation in `StartDockerProxy` and `runProxyListener` is verified
+
+Key paths to cover:
+- `server.go` 96–97: `session.StartDockerProxy()` error return
+- `session.go` 127–128: yamux session error in `NewAgentSession`
+- `session.go` 160–161, 167–175: `StartDockerProxy` closed-session and double-check paths
+- `session.go` 199–203: `runProxyListener` transient retry logic
+
+### Recommendation 2 — Add CVE-2026-32286 to SECURITY.md
+
+`github.com/jackc/pgproto3/v2` v2.3.3 is not yet documented in `SECURITY.md`. See
+[SECURITY.md Updates](#securitymd-updates).
+
+---
+
+## SECURITY.md Updates
+
+The following entry should be added to `SECURITY.md` under **Known Vulnerabilities**.
+
+```markdown
+### [HIGH] CVE-2026-32286 · pgproto3 DoS via Negative DataRow Field Length
+
+| Field        | Value |
+|--------------|-------|
+| **ID**       | CVE-2026-32286 |
+| **Severity** | High · 7.5 |
+| **Status**   | Awaiting Upstream |
+
+**What**
+`github.com/jackc/pgproto3/v2` v2.3.3 — `DataRow.Decode` does not validate field length
+before allocation. A malicious PostgreSQL server can send a negative field length to trigger
+a panic or excessive memory allocation, causing denial of service.
+
+**Who**
+
+- Discovered by: Automated scan (Trivy image scan)
+- Reported: 2026-05-20
+- Affects: Charon deployments connecting to untrusted PostgreSQL servers (not the default
+  SQLite deployment)
+
+**Where**
+
+- Component: `github.com/jackc/pgproto3/v2` v2.3.3 (transitive dependency)
+- Versions affected: pgproto3/v2 < patched version
+
+**When**
+
+- Discovered: 2026-05-20
+- Disclosed (if public): Public
+- Target fix: When upstream publishes a patched release
+
+**How**
+Exploitation requires a malicious or compromised PostgreSQL server to send a crafted DataRow
+message. Charon's default installation uses SQLite and does not connect to PostgreSQL. Users
+deploying Charon with a PostgreSQL backend (non-standard) are potentially exposed if the
+database server is untrusted. EPSS score not yet available.
+
+**Planned Remediation**
+Monitor https://github.com/jackc/pgproto3 for a fix release. Upgrade the indirect dependency
+once a patched version is available.
+```
+
+CVE-2026-45135 (Caddy) does not require a `SECURITY.md` entry because the Dockerfile already
+pins the fix (v2.11.3) — it is remediated at the source level pending an image rebuild.
+
+---
+
+## Appendix — PR Scope Files
+
+| File                                                          | Type     | Notes                        |
+|---------------------------------------------------------------|----------|------------------------------|
+| `backend/internal/orthrus/session.go`                         | Modified | Core proxy implementation    |
+| `backend/internal/orthrus/server.go`                          | Modified | Agent server integration     |
+| `backend/internal/orthrus/session_external_proxy_test.go`     | New      | Unit tests for external proxy|
+| `backend/internal/orthrus/session_proxy_test.go`              | New      | Proxy helper tests           |
+| `backend/internal/models/orthrus_agent.go`                    | Modified | `ExternalProxyPort` field    |
+| `frontend/src/components/hecate/OrthrusAgentManager.tsx`      | Modified | Proxy dialog + badge         |
+| `frontend/src/locales/{en,es,fr,de,zh}/translation.json`      | Modified | i18n — key missing           |
+| `tests/orthrus-external-proxy.spec.ts`                        | New      | E2E tests (2/9 pass)         |
+| `Dockerfile`                                                  | Modified | Caddy ARG updated to 2.11.3  |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1086,9 +1086,9 @@
       }
     },
     "node_modules/@exodus/bytes": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3384,9 +3384,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.100.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.10.tgz",
-      "integrity": "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==",
+      "version": "5.100.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.11.tgz",
+      "integrity": "sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3394,12 +3394,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.100.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.10.tgz",
-      "integrity": "sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==",
+      "version": "5.100.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.11.tgz",
+      "integrity": "sha512-J0f9s5x3LE1450nNNfYx+e/n0DMa0uOBdFJUy5r0RvmsXd4nB/n0rbHtHI1vYXhikNFan+wf51p6Tmp4c8ucrg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.100.10"
+        "@tanstack/query-core": "5.100.11"
       },
       "funding": {
         "type": "github",
@@ -3902,9 +3902,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3912,9 +3912,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3945,17 +3945,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
-      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
+      "integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/type-utils": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/type-utils": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -3968,22 +3968,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.3",
+        "@typescript-eslint/parser": "^8.59.4",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
-      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
+      "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3999,14 +3999,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
-      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
+      "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.3",
-        "@typescript-eslint/types": "^8.59.3",
+        "@typescript-eslint/tsconfig-utils": "^8.59.4",
+        "@typescript-eslint/types": "^8.59.4",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4021,14 +4021,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
+      "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3"
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4039,9 +4039,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
-      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
+      "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4056,15 +4056,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
-      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
+      "integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4081,9 +4081,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
+      "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4095,16 +4095,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
-      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
+      "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.3",
-        "@typescript-eslint/tsconfig-utils": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/project-service": "8.59.4",
+        "@typescript-eslint/tsconfig-utils": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4123,16 +4123,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
-      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
+      "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3"
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4147,13 +4147,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
+      "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/types": "8.59.4",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4178,9 +4178,9 @@
       }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
       "cpu": [
         "arm"
       ],
@@ -4192,9 +4192,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
       "cpu": [
         "arm64"
       ],
@@ -4206,9 +4206,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
       "cpu": [
         "arm64"
       ],
@@ -4220,9 +4220,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
       "cpu": [
         "x64"
       ],
@@ -4234,9 +4234,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
       "cpu": [
         "x64"
       ],
@@ -4248,9 +4248,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
       "cpu": [
         "arm"
       ],
@@ -4262,9 +4262,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
       "cpu": [
         "arm"
       ],
@@ -4276,9 +4276,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
       "cpu": [
         "arm64"
       ],
@@ -4293,9 +4293,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
       "cpu": [
         "arm64"
       ],
@@ -4309,10 +4309,44 @@
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
       "cpu": [
         "ppc64"
       ],
@@ -4327,9 +4361,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
       "cpu": [
         "riscv64"
       ],
@@ -4344,9 +4378,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
       "cpu": [
         "riscv64"
       ],
@@ -4361,9 +4395,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
       "cpu": [
         "s390x"
       ],
@@ -4378,9 +4412,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
       "cpu": [
         "x64"
       ],
@@ -4395,9 +4429,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
       "cpu": [
         "x64"
       ],
@@ -4411,10 +4445,24 @@
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
       "cpu": [
         "wasm32"
       ],
@@ -4422,29 +4470,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
-      }
-    },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
       "cpu": [
         "arm64"
       ],
@@ -4456,9 +4493,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
       "cpu": [
         "ia32"
       ],
@@ -4470,9 +4507,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
       "cpu": [
         "x64"
       ],
@@ -4510,9 +4547,9 @@
       }
     },
     "node_modules/@vitest/coverage-istanbul": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.6.tgz",
-      "integrity": "sha512-lOt/VDh+sihAx3OUxCE5CC0qZfAhIzE3Dxw75NJ3P0C6ruUgT9b/jZKECE1ctpbxSVic9OkLdXz5UEX39ks4Sw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.7.tgz",
+      "integrity": "sha512-EbruXy+E9MJk+y7sFzriYfoI4JP2Ow+SyWDkewFOWFjzrbQBHlEgi6dGE7pxge8Z+W+7oJOxAVVb6mQHKCCZlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4531,18 +4568,18 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.6"
+        "vitest": "4.1.7"
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.7",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -4556,8 +4593,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.6",
-        "vitest": "4.1.6"
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -4597,16 +4634,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -4615,13 +4652,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.6",
+        "@vitest/spy": "4.1.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4642,9 +4679,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4655,13 +4692,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4669,14 +4706,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4685,9 +4722,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4695,13 +4732,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.6.tgz",
-      "integrity": "sha512-wiu5em68DfGv/2HFvI1Njr7JI2CHcBlQvereSzVG8my53PRxjTNOCsD9VOkRKrsJBDHmyuXvosxWZw7T91a2mw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.7.tgz",
+      "integrity": "sha512-TP6utB2yX6rsJNVRo2qAlsi48i1YwFTrLV2tnTtWqJaYX7m4lRCCLirZBjU6xC5m0RsPHr+L2+N+eIPhgEzFfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.7",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -4713,17 +4750,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.6"
+        "vitest": "4.1.7"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
+        "@vitest/pretty-format": "4.1.7",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -5085,9 +5122,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5237,9 +5274,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -5728,9 +5765,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.2.1.tgz",
+      "integrity": "sha512-37RhSdxaG1suen6VDCza6rNrQfooyQh57HFVPwQGEq2QWliVLzPQZ8Oa017weOu+HZCnzI7N3Pf/wyoBKfEqrA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5896,9 +5933,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.356",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.356.tgz",
-      "integrity": "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==",
+      "version": "1.5.360",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
+      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5910,9 +5947,9 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
-      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
+      "version": "5.21.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.5.tgz",
+      "integrity": "sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7997,9 +8034,9 @@
       }
     },
     "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -8080,9 +8117,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.46",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.46.tgz",
-      "integrity": "sha512-WHy4Coo+bGZyH7NwJKHkS04YFsFcarWbAEOAC3EMndzdN6VSZqklLLIgfxzyaW9jDoeGYJX9SWbJPKpecox0Uw==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",
@@ -9954,9 +9991,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -9974,7 +10011,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11227,16 +11264,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
-      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.4.tgz",
+      "integrity": "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.3",
-        "@typescript-eslint/parser": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3"
+        "@typescript-eslint/eslint-plugin": "8.59.4",
+        "@typescript-eslint/parser": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11371,38 +11408,41 @@
       }
     },
     "node_modules/unrs-resolver": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "napi-postinstall": "^0.3.0"
+        "napi-postinstall": "^0.3.4"
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-        "@unrs/resolver-binding-android-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-x64": "1.11.1",
-        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -11614,19 +11654,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -11654,12 +11694,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/frontend/src/api/__tests__/orthrus.test.ts
+++ b/frontend/src/api/__tests__/orthrus.test.ts
@@ -10,6 +10,7 @@ import {
   getInstallSnippets,
   patchAgent,
   renameAgent,
+  getAgentProxyStatus,
 } from '../orthrus'
 
 vi.mock('../client', () => ({
@@ -173,6 +174,32 @@ describe('orthrus API', () => {
     it('propagates errors', async () => {
       vi.mocked(client.get).mockRejectedValue(new Error('snippets failed'))
       await expect(getInstallSnippets('agent-uuid')).rejects.toThrow('snippets failed')
+    })
+  })
+
+  describe('getAgentProxyStatus', () => {
+    it('calls the proxy-status endpoint and returns data', async () => {
+      const status = {
+        agent_uuid: 'agent-uuid',
+        agent_online: true,
+        configured_port: 2375,
+        active: true,
+        active_port: 2375,
+        bind_address: '0.0.0.0:2375',
+        connection_string: 'tcp://charon:2375',
+        error: '',
+      }
+      vi.mocked(client.get).mockResolvedValue({ data: status })
+
+      const result = await getAgentProxyStatus('agent-uuid')
+
+      expect(client.get).toHaveBeenCalledWith('/orthrus/agents/agent-uuid/proxy-status')
+      expect(result).toEqual(status)
+    })
+
+    it('propagates errors', async () => {
+      vi.mocked(client.get).mockRejectedValue(new Error('proxy status failed'))
+      await expect(getAgentProxyStatus('agent-uuid')).rejects.toThrow('proxy status failed')
     })
   })
 })

--- a/frontend/src/api/orthrus.ts
+++ b/frontend/src/api/orthrus.ts
@@ -16,6 +16,8 @@ export interface OrthrusAgent {
   hecate_tunnel_uuid?: string;
   device_id?: string;
   resolved_address?: string;
+  // External Docker proxy port (0 = disabled, 1024–65535 = enabled)
+  external_proxy_port: number;
 }
 
 export interface PatchAgentRequest {
@@ -23,6 +25,18 @@ export interface PatchAgentRequest {
   hecate_tunnel_uuid?: string | null;
   device_id?: string | null;
   resolved_address?: string | null;
+  external_proxy_port?: number;
+}
+
+export interface ExternalProxyStatus {
+  agent_uuid: string;
+  agent_online: boolean;
+  configured_port: number;
+  active: boolean;
+  active_port: number;
+  bind_address: string;
+  connection_string: string;
+  error: string;
 }
 
 export interface ProvisionAgentRequest {
@@ -81,5 +95,10 @@ export const getInstallSnippets = async (uuid: string): Promise<InstallSnippets>
   const { data } = await client.get<InstallSnippets>(`/orthrus/agents/${uuid}/snippets`, {
     headers: { 'X-Charon-URL': window.location.origin },
   });
+  return data;
+};
+
+export const getAgentProxyStatus = async (agentUUID: string): Promise<ExternalProxyStatus> => {
+  const { data } = await client.get<ExternalProxyStatus>(`/orthrus/agents/${agentUUID}/proxy-status`);
   return data;
 };

--- a/frontend/src/components/hecate/AgentExternalProxyDialog.tsx
+++ b/frontend/src/components/hecate/AgentExternalProxyDialog.tsx
@@ -1,0 +1,250 @@
+import { AlertTriangle, CheckCircle2, Circle, Copy, XCircle } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { type OrthrusAgent } from '../../api/orthrus';
+import { useAgentProxyStatus, usePatchAgent } from '../../hooks/useOrthrus';
+import { Button } from '../ui/Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/Dialog';
+
+interface AgentExternalProxyDialogProps {
+  agent: OrthrusAgent;
+  open: boolean;
+  onClose: () => void;
+}
+
+function validatePort(value: number): string | null {
+  if (value === 0) return null;
+  if (value >= 1 && value <= 1023) return 'Port must be 0 (disabled) or in range 1024–65535.';
+  if (value > 65535) return 'Port must be 0 (disabled) or in range 1024–65535.';
+  return null;
+}
+
+export function AgentExternalProxyDialog({
+  agent,
+  open,
+  onClose,
+}: AgentExternalProxyDialogProps) {
+  const { t } = useTranslation();
+  const { mutate: patch, isPending } = usePatchAgent();
+
+  const [portValue, setPortValue] = useState(agent.external_proxy_port ?? 0);
+  const [portError, setPortError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const isOnline = agent.status === 'online';
+
+  const { data: proxyStatus, refetch: refetchStatus } = useAgentProxyStatus(
+    agent.uuid,
+    open && isOnline,
+  );
+
+  useEffect(() => {
+    if (open) {
+      setPortValue(agent.external_proxy_port ?? 0);
+      setPortError(null);
+      setCopied(false);
+    }
+  }, [open, agent.external_proxy_port]);
+
+  const handlePortChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = parseInt(e.target.value, 10);
+    const num = isNaN(raw) ? 0 : raw;
+    setPortValue(num);
+    setPortError(validatePort(num));
+  };
+
+  const handleSave = () => {
+    const err = validatePort(portValue);
+    if (err) {
+      setPortError(err);
+      return;
+    }
+    patch(
+      { uuid: agent.uuid, req: { external_proxy_port: portValue } },
+      {
+        onSuccess: () => {
+          void refetchStatus();
+          onClose();
+        },
+      },
+    );
+  };
+
+  const handleCopy = async (text: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 3000);
+  };
+
+  const configuredDiffersFromActive =
+    proxyStatus?.active &&
+    proxyStatus.active_port !== 0 &&
+    proxyStatus.active_port !== portValue;
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {t('hecate.externalProxy.title', { name: agent.name })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('hecate.externalProxy.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-2">
+          {/* Port input */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="external-proxy-port"
+              className="block text-sm font-medium text-content-primary"
+            >
+              {t('hecate.externalProxy.portLabel')}
+            </label>
+            <input
+              id="external-proxy-port"
+              type="number"
+              min={0}
+              max={65535}
+              step={1}
+              value={portValue}
+              onChange={handlePortChange}
+              placeholder="0"
+              aria-describedby="external-proxy-port-hint external-proxy-port-error"
+              aria-invalid={portError !== null}
+              className="w-full bg-surface-subtle border border-border rounded-lg px-4 py-2 text-content-primary focus:outline-none focus:ring-2 focus:ring-blue-500 aria-[invalid=true]:border-destructive"
+            />
+            <p id="external-proxy-port-hint" className="text-xs text-content-muted">
+              {t('hecate.externalProxy.portHint')}
+            </p>
+            {portError && (
+              <p
+                id="external-proxy-port-error"
+                role="alert"
+                className="text-xs text-destructive"
+              >
+                {portError}
+              </p>
+            )}
+          </div>
+
+          {/* Security warning */}
+          <div
+            role="note"
+            className="flex gap-2 rounded-lg border border-warning/30 bg-warning/10 p-3"
+          >
+            <AlertTriangle
+              className="h-4 w-4 shrink-0 text-warning mt-0.5"
+              aria-hidden="true"
+            />
+            <p className="text-xs text-content-secondary">
+              {t('hecate.externalProxy.securityWarning')}
+            </p>
+          </div>
+
+          {/* Live status */}
+          {isOnline && proxyStatus && (
+            <div
+              role="status"
+              aria-live="polite"
+              aria-label={t('hecate.externalProxy.statusLabel')}
+              className="space-y-2"
+            >
+              <p className="text-sm font-medium text-content-primary">
+                {t('hecate.externalProxy.statusHeading')}
+              </p>
+
+              {proxyStatus.error ? (
+                <div className="flex items-center gap-2" role="alert">
+                  <XCircle className="h-4 w-4 text-destructive" aria-hidden="true" />
+                  <span className="text-sm text-destructive">{proxyStatus.error}</span>
+                </div>
+              ) : !proxyStatus.agent_online ? (
+                <div className="flex items-center gap-2">
+                  <Circle className="h-4 w-4 text-content-muted" aria-hidden="true" />
+                  <span className="text-sm text-content-muted">
+                    {t('hecate.externalProxy.agentOffline')}
+                  </span>
+                </div>
+              ) : proxyStatus.active ? (
+                <div className="flex items-center gap-2 flex-wrap">
+                  <CheckCircle2 className="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+                  <span className="text-sm text-success font-medium">
+                    {t('hecate.externalProxy.statusActive')}
+                  </span>
+                  {proxyStatus.connection_string && (
+                    <>
+                      <code className="text-sm font-mono text-content-primary bg-surface-subtle px-1.5 py-0.5 rounded">
+                        {proxyStatus.connection_string}
+                      </code>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2"
+                        onClick={() => void handleCopy(proxyStatus.connection_string)}
+                        aria-label={t('hecate.externalProxy.copyConnectionString')}
+                      >
+                        {copied ? (
+                          <CheckCircle2 className="h-3.5 w-3.5 text-success" aria-hidden="true" />
+                        ) : (
+                          <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+                        )}
+                      </Button>
+                    </>
+                  )}
+                </div>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <Circle className="h-4 w-4 text-content-muted" aria-hidden="true" />
+                  <span className="text-sm text-content-muted">
+                    {t('hecate.externalProxy.statusInactive')}
+                  </span>
+                </div>
+              )}
+
+              {configuredDiffersFromActive && (
+                <p className="text-xs text-content-secondary italic">
+                  {t('hecate.externalProxy.reconnectNotice')}
+                </p>
+              )}
+            </div>
+          )}
+
+          {!isOnline && (
+            <div
+              role="status"
+              aria-live="polite"
+              className="flex items-center gap-2"
+            >
+              <Circle className="h-4 w-4 text-content-muted" aria-hidden="true" />
+              <span className="text-sm text-content-muted">
+                {t('hecate.externalProxy.agentOffline')}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isPending}>
+            {t('common.cancel')}
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={isPending || portError !== null}
+          >
+            {t('common.save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/hecate/OrthrusAgentManager.tsx
+++ b/frontend/src/components/hecate/OrthrusAgentManager.tsx
@@ -1,10 +1,11 @@
-import { Check, Link2, Pencil, Trash2, X } from 'lucide-react';
+import { Check, Link2, Pencil, Settings, Trash2, X } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { AgentExternalProxyDialog } from './AgentExternalProxyDialog';
+import { AgentProviderAssignDialog } from './AgentProviderAssignDialog';
 import { type OrthrusAgent } from '../../api/orthrus';
 import { useDeleteAgent, useRenameAgent } from '../../hooks/useOrthrus';
-import { AgentProviderAssignDialog } from './AgentProviderAssignDialog';
 import { Badge } from '../ui/Badge';
 import { Button } from '../ui/Button';
 import {
@@ -35,9 +36,10 @@ interface AgentRowProps {
   agent: OrthrusAgent;
   onDelete: (uuid: string, name: string) => void;
   onAssignProvider: (agent: OrthrusAgent) => void;
+  onConfigureProxy: (agent: OrthrusAgent) => void;
 }
 
-const AgentRow = ({ agent, onDelete, onAssignProvider }: AgentRowProps) => {
+const AgentRow = ({ agent, onDelete, onAssignProvider, onConfigureProxy }: AgentRowProps) => {
   const { t } = useTranslation();
   const { mutate: rename, isPending: isRenaming } = useRenameAgent();
   const [editing, setEditing] = useState(false);
@@ -132,9 +134,16 @@ const AgentRow = ({ agent, onDelete, onAssignProvider }: AgentRowProps) => {
 
       {/* Status */}
       <td className="py-3 px-4">
-        <Badge variant={statusVariant(agent.status)} className="capitalize">
-          {t(`hecate.agentManager.status.${agent.status}`)}
-        </Badge>
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <Badge variant={statusVariant(agent.status)} className="capitalize">
+            {t(`hecate.agentManager.status.${agent.status}`)}
+          </Badge>
+          {agent.external_proxy_port > 0 && (
+            <Badge variant="secondary" className="uppercase text-[10px]">
+              PROXY
+            </Badge>
+          )}
+        </div>
       </td>
 
       {/* Provider */}
@@ -164,6 +173,15 @@ const AgentRow = ({ agent, onDelete, onAssignProvider }: AgentRowProps) => {
             variant="ghost"
             size="sm"
             className="h-7 w-7 p-0 text-content-tertiary hover:text-brand-500"
+            onClick={() => onConfigureProxy(agent)}
+            aria-label={t('hecate.agentManager.configureProxy', { name: agent.name })}
+          >
+            <Settings className="h-3.5 w-3.5" aria-hidden="true" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0 text-content-tertiary hover:text-brand-500"
             onClick={() => onAssignProvider(agent)}
             aria-label={t('hecate.agentManager.assignProvider', { name: agent.name })}
           >
@@ -189,6 +207,7 @@ export const OrthrusAgentManager = ({ agents }: OrthrusAgentManagerProps) => {
   const { mutate: deleteAgent, isPending: isDeleting } = useDeleteAgent();
   const [confirmDelete, setConfirmDelete] = useState<{ uuid: string; name: string } | null>(null);
   const [assignProviderAgent, setAssignProviderAgent] = useState<OrthrusAgent | null>(null);
+  const [proxyConfigAgent, setProxyConfigAgent] = useState<OrthrusAgent | null>(null);
 
   const handleDeleteRequest = (uuid: string, name: string) => {
     setConfirmDelete({ uuid, name });
@@ -242,6 +261,7 @@ export const OrthrusAgentManager = ({ agents }: OrthrusAgentManagerProps) => {
                 agent={agent}
                 onDelete={handleDeleteRequest}
                 onAssignProvider={setAssignProviderAgent}
+                onConfigureProxy={setProxyConfigAgent}
               />
             ))}
           </tbody>
@@ -273,6 +293,14 @@ export const OrthrusAgentManager = ({ agents }: OrthrusAgentManagerProps) => {
           agent={assignProviderAgent}
           open={!!assignProviderAgent}
           onClose={() => setAssignProviderAgent(null)}
+        />
+      )}
+      {/* External Docker Proxy dialog */}
+      {proxyConfigAgent && (
+        <AgentExternalProxyDialog
+          agent={proxyConfigAgent}
+          open={!!proxyConfigAgent}
+          onClose={() => setProxyConfigAgent(null)}
         />
       )}
     </>

--- a/frontend/src/components/hecate/__tests__/AgentExternalProxyDialog.test.tsx
+++ b/frontend/src/components/hecate/__tests__/AgentExternalProxyDialog.test.tsx
@@ -1,0 +1,241 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { type OrthrusAgent } from '../../../api/orthrus';
+import { AgentExternalProxyDialog } from '../AgentExternalProxyDialog';
+
+const mockPatch = vi.fn();
+const mockRefetchStatus = vi.fn();
+let mockProxyStatus: Record<string, unknown> | undefined = undefined;
+
+vi.mock('../../../hooks/useOrthrus', () => ({
+  usePatchAgent: () => ({ mutate: mockPatch, isPending: false }),
+  useAgentProxyStatus: () => ({
+    data: mockProxyStatus,
+    refetch: mockRefetchStatus,
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, string>) =>
+      opts?.name ? `${key}:${opts.name}` : key,
+  }),
+}));
+
+const baseAgent: OrthrusAgent = {
+  uuid: 'agent-1',
+  name: 'Test Agent',
+  status: 'online',
+  capabilities: '["proxy"]',
+  hecate_tunnel_uuid: undefined,
+  resolved_address: undefined,
+  device_id: undefined,
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+  external_proxy_port: 2375,
+};
+
+const renderDialog = (agent: OrthrusAgent = baseAgent, open = true, onClose = vi.fn()) =>
+  render(<AgentExternalProxyDialog agent={agent} open={open} onClose={onClose} />);
+
+beforeEach(() => {
+  mockPatch.mockReset();
+  mockRefetchStatus.mockReset();
+  mockProxyStatus = undefined;
+});
+
+describe('AgentExternalProxyDialog', () => {
+  describe('port validation', () => {
+    it('shows no error for port 0', () => {
+      renderDialog({ ...baseAgent, external_proxy_port: 0 });
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('shows no error for a valid port in 1024–65535', () => {
+      renderDialog({ ...baseAgent, external_proxy_port: 2375 });
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('shows an error when port is changed to a privileged value (1–1023)', () => {
+      renderDialog({ ...baseAgent, external_proxy_port: 0 });
+      const input = screen.getByRole('spinbutton');
+      fireEvent.change(input, { target: { value: '80' } });
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('shows an error when port exceeds 65535', () => {
+      renderDialog({ ...baseAgent, external_proxy_port: 0 });
+      const input = screen.getByRole('spinbutton');
+      fireEvent.change(input, { target: { value: '99999' } });
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('clears error when port is changed to 0', () => {
+      renderDialog({ ...baseAgent, external_proxy_port: 0 });
+      const input = screen.getByRole('spinbutton');
+      fireEvent.change(input, { target: { value: '80' } });
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      fireEvent.change(input, { target: { value: '0' } });
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('handleSave', () => {
+    it('calls patch with the current port when valid', () => {
+      renderDialog();
+      fireEvent.click(screen.getByText('common.save'));
+      expect(mockPatch).toHaveBeenCalledWith(
+        { uuid: 'agent-1', req: { external_proxy_port: 2375 } },
+        expect.any(Object),
+      );
+    });
+
+    it('does not call patch when port is invalid', () => {
+      renderDialog({ ...baseAgent, external_proxy_port: 0 });
+      const input = screen.getByRole('spinbutton');
+      fireEvent.change(input, { target: { value: '80' } });
+      fireEvent.click(screen.getByText('common.save'));
+      expect(mockPatch).not.toHaveBeenCalled();
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('calls refetchStatus and onClose on successful save', async () => {
+      const onClose = vi.fn();
+      mockPatch.mockImplementation((_args: unknown, { onSuccess }: { onSuccess: () => void }) => {
+        onSuccess();
+      });
+      renderDialog(baseAgent, true, onClose);
+      fireEvent.click(screen.getByText('common.save'));
+      expect(mockRefetchStatus).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('offline agent', () => {
+    it('shows offline status when agent is not online', () => {
+      renderDialog({ ...baseAgent, status: 'offline' });
+      const statusNodes = screen.getAllByText('hecate.externalProxy.agentOffline');
+      expect(statusNodes.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('live proxy status', () => {
+    it('shows error state when proxyStatus.error is set', () => {
+      mockProxyStatus = {
+        agent_uuid: 'agent-1',
+        agent_online: true,
+        configured_port: 2375,
+        active: false,
+        active_port: 0,
+        bind_address: '',
+        connection_string: '',
+        error: 'bind failed: address already in use',
+      };
+      renderDialog();
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText('bind failed: address already in use')).toBeInTheDocument();
+    });
+
+    it('shows offline message when proxyStatus.agent_online is false', () => {
+      mockProxyStatus = {
+        agent_uuid: 'agent-1',
+        agent_online: false,
+        configured_port: 2375,
+        active: false,
+        active_port: 0,
+        bind_address: '',
+        connection_string: '',
+        error: '',
+      };
+      renderDialog();
+      const offlineMessages = screen.getAllByText('hecate.externalProxy.agentOffline');
+      expect(offlineMessages.length).toBeGreaterThan(0);
+    });
+
+    it('shows active status with connection string when proxy is active', () => {
+      mockProxyStatus = {
+        agent_uuid: 'agent-1',
+        agent_online: true,
+        configured_port: 2375,
+        active: true,
+        active_port: 2375,
+        bind_address: '0.0.0.0:2375',
+        connection_string: 'tcp://charon:2375',
+        error: '',
+      };
+      renderDialog();
+      expect(screen.getByText('hecate.externalProxy.statusActive')).toBeInTheDocument();
+      expect(screen.getByText('tcp://charon:2375')).toBeInTheDocument();
+    });
+
+    it('shows inactive status when proxy is not active', () => {
+      mockProxyStatus = {
+        agent_uuid: 'agent-1',
+        agent_online: true,
+        configured_port: 2375,
+        active: false,
+        active_port: 0,
+        bind_address: '',
+        connection_string: '',
+        error: '',
+      };
+      renderDialog();
+      expect(screen.getByText('hecate.externalProxy.statusInactive')).toBeInTheDocument();
+    });
+
+    it('shows reconnect notice when configured port differs from active port', () => {
+      mockProxyStatus = {
+        agent_uuid: 'agent-1',
+        agent_online: true,
+        configured_port: 2375,
+        active: true,
+        active_port: 9999,
+        bind_address: '0.0.0.0:9999',
+        connection_string: 'tcp://charon:9999',
+        error: '',
+      };
+      renderDialog({ ...baseAgent, external_proxy_port: 2375 });
+      expect(screen.getByText('hecate.externalProxy.reconnectNotice')).toBeInTheDocument();
+    });
+  });
+
+  describe('handleCopy', () => {
+    it('copies connection string to clipboard and shows copied state', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      mockProxyStatus = {
+        agent_uuid: 'agent-1',
+        agent_online: true,
+        configured_port: 2375,
+        active: true,
+        active_port: 2375,
+        bind_address: '0.0.0.0:2375',
+        connection_string: 'tcp://charon:2375',
+        error: '',
+      };
+      renderDialog();
+
+      const copyButton = screen.getByRole('button', {
+        name: 'hecate.externalProxy.copyConnectionString',
+      });
+      await act(async () => {
+        fireEvent.click(copyButton);
+      });
+
+      await waitFor(() =>
+        expect(writeText).toHaveBeenCalledWith('tcp://charon:2375'),
+      );
+    });
+  });
+
+  describe('cancel button', () => {
+    it('calls onClose when cancel is clicked', () => {
+      const onClose = vi.fn();
+      renderDialog(baseAgent, true, onClose);
+      fireEvent.click(screen.getByText('common.cancel'));
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/hecate/__tests__/AgentProviderAssignDialog.test.tsx
+++ b/frontend/src/components/hecate/__tests__/AgentProviderAssignDialog.test.tsx
@@ -67,6 +67,7 @@ const baseAgent = {
   capabilities: '["proxy"]',
   created_at: '2025-01-01T00:00:00Z',
   updated_at: '2025-01-01T00:00:00Z',
+  external_proxy_port: 0,
 };
 
 describe('AgentProviderAssignDialog', () => {

--- a/frontend/src/components/hecate/__tests__/OrthrusAgentManager.test.tsx
+++ b/frontend/src/components/hecate/__tests__/OrthrusAgentManager.test.tsx
@@ -30,6 +30,23 @@ vi.mock('../AgentProviderAssignDialog', () => ({
     ) : null,
 }));
 
+vi.mock('../AgentExternalProxyDialog', () => ({
+  AgentExternalProxyDialog: ({
+    open,
+    onClose,
+    agent,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    agent: { name: string };
+  }) =>
+    open ? (
+      <div data-testid="proxy-dialog" aria-label={`proxy-dialog-${agent.name}`}>
+        <button onClick={onClose}>CloseProxy</button>
+      </div>
+    ) : null,
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, opts?: Record<string, string>) =>
@@ -351,5 +368,39 @@ describe('OrthrusAgentManager', () => {
         }),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it('clicking configure proxy button opens the proxy dialog', async () => {
+    renderManager([agentWithProvider]);
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: `hecate.agentManager.configureProxy:${agentWithProvider.name}`,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('proxy-dialog')).toBeInTheDocument(),
+    );
+  });
+
+  it('proxy dialog onClose clears proxyConfigAgent', async () => {
+    renderManager([agentWithProvider]);
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: `hecate.agentManager.configureProxy:${agentWithProvider.name}`,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('proxy-dialog')).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByText('CloseProxy'));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('proxy-dialog')).not.toBeInTheDocument(),
+    );
   });
 });

--- a/frontend/src/components/hecate/__tests__/OrthrusAgentManager.test.tsx
+++ b/frontend/src/components/hecate/__tests__/OrthrusAgentManager.test.tsx
@@ -47,6 +47,7 @@ const agentWithProvider = {
   device_id: 'ts-device-1',
   created_at: '2025-01-01T00:00:00Z',
   updated_at: '2025-01-01T00:00:00Z',
+  external_proxy_port: 0,
 };
 
 const agentWithoutProvider = {
@@ -59,6 +60,7 @@ const agentWithoutProvider = {
   device_id: undefined,
   created_at: '2025-01-01T00:00:00Z',
   updated_at: '2025-01-01T00:00:00Z',
+  external_proxy_port: 0,
 };
 
 const agentWithDeviceIdOnly = {
@@ -71,6 +73,7 @@ const agentWithDeviceIdOnly = {
   device_id: 'ts-device-abc',
   created_at: '2025-01-01T00:00:00Z',
   updated_at: '2025-01-01T00:00:00Z',
+  external_proxy_port: 0,
 };
 
 const agentTunnelOnly = {
@@ -83,6 +86,7 @@ const agentTunnelOnly = {
   device_id: undefined,
   created_at: '2025-01-01T00:00:00Z',
   updated_at: '2025-01-01T00:00:00Z',
+  external_proxy_port: 0,
 };
 
 function renderManager(agents: OrthrusAgent[]) {

--- a/frontend/src/hooks/__tests__/useOrthrus.test.tsx
+++ b/frontend/src/hooks/__tests__/useOrthrus.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import * as api from '../../api/orthrus'
-import { useOrthrus, useAgentList, useProvisionAgent, useRenameAgent, useDeleteAgent, AGENTS_QUERY_KEY } from '../useOrthrus'
+import { useOrthrus, useAgentList, useProvisionAgent, useRenameAgent, useDeleteAgent, useAgentProxyStatus, AGENTS_QUERY_KEY } from '../useOrthrus'
 
 vi.mock('../../api/orthrus', () => ({
   listAgents: vi.fn(),
@@ -13,6 +13,7 @@ vi.mock('../../api/orthrus', () => ({
   deleteAgent: vi.fn(),
   revokeAgent: vi.fn(),
   getInstallSnippets: vi.fn(),
+  getAgentProxyStatus: vi.fn(),
 }))
 
 const createWrapper = () => {
@@ -220,5 +221,40 @@ describe('useOrthrus', () => {
     expect(result.current.isDeleting).toBe(false)
     expect(result.current.isRevoking).toBe(false)
     expect(result.current.isFetchingSnippets).toBe(false)
+  })
+})
+
+describe('useAgentProxyStatus', () => {
+  it('fetches proxy status when enabled', async () => {
+    const status = {
+      agent_uuid: 'agent-1',
+      agent_online: true,
+      configured_port: 2375,
+      active: true,
+      active_port: 2375,
+      bind_address: '0.0.0.0:2375',
+      connection_string: 'tcp://charon:2375',
+      error: '',
+    }
+    vi.mocked(api.getAgentProxyStatus).mockResolvedValue(status)
+
+    const { result } = renderHook(
+      () => useAgentProxyStatus('agent-1', true),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(status)
+    expect(api.getAgentProxyStatus).toHaveBeenCalledWith('agent-1')
+  })
+
+  it('does not fetch when disabled', () => {
+    const { result } = renderHook(
+      () => useAgentProxyStatus('agent-1', false),
+      { wrapper: createWrapper() },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(api.getAgentProxyStatus).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/hooks/__tests__/useOrthrus.test.tsx
+++ b/frontend/src/hooks/__tests__/useOrthrus.test.tsx
@@ -31,6 +31,7 @@ const mockAgent: api.OrthrusAgent = {
   capabilities: '["proxy"]',
   created_at: '2025-01-01T00:00:00Z',
   updated_at: '2025-01-01T00:00:00Z',
+  external_proxy_port: 0,
 }
 
 describe('AGENTS_QUERY_KEY', () => {

--- a/frontend/src/hooks/useOrthrus.ts
+++ b/frontend/src/hooks/useOrthrus.ts
@@ -2,12 +2,14 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
   deleteAgent,
+  getAgentProxyStatus,
   getInstallSnippets,
   listAgents,
   patchAgent,
   provisionAgent,
   renameAgent,
   revokeAgent,
+  type ExternalProxyStatus,
   type OrthrusAgent,
   type PatchAgentRequest,
   type ProvisionAgentRequest,
@@ -61,6 +63,14 @@ export const useDeleteAgent = () => {
     },
   });
 };
+
+export const useAgentProxyStatus = (agentUUID: string, enabled: boolean) =>
+  useQuery<ExternalProxyStatus>({
+    queryKey: ['orthrus', 'agents', agentUUID, 'proxy-status'],
+    queryFn: () => getAgentProxyStatus(agentUUID),
+    enabled,
+    staleTime: 10_000,
+  });
 
 export const useOrthrus = () => {
   const queryClient = useQueryClient();

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -1227,7 +1227,22 @@
         "online": "Online",
         "offline": "Offline",
         "pending": "Ausstehend"
-      }
+      },
+      "configureProxy": "Configure proxy for {{name}}"
+    },
+    "externalProxy": {
+      "title": "Externer Docker-Proxy",
+      "description": "Konfigurieren Sie einen TCP-Port, um die Docker-API dieses Agenten im Netzwerk bereitzustellen.",
+      "portLabel": "Port",
+      "portHint": "Geben Sie einen Port (1024–65535) zum Aktivieren oder 0 zum Deaktivieren ein.",
+      "securityWarning": "Dadurch werden Docker-API-Endpunkte in Ihrem lokalen Netzwerk freigegeben. Stellen Sie sicher, dass der Port durch eine Firewall geschützt und nur für vertrauenswürdige Hosts zugänglich ist.",
+      "statusLabel": "Proxy-Status",
+      "statusHeading": "Aktueller Status",
+      "statusActive": "Aktiv",
+      "statusInactive": "Inaktiv",
+      "copyConnectionString": "Docker-Verbindungszeichenfolge kopieren",
+      "reconnectNotice": "Portänderung wird bei der nächsten Agentenverbindung wirksam.",
+      "agentOffline": "Agent ist offline. Proxy-Status nicht verfügbar."
     }
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1762,7 +1762,22 @@
       "deviceId": "Device / Peer ID",
       "resolvedAddress": "Resolved Address",
       "saveProviderAssignment": "Save Assignment",
-      "removeProviderAssignment": "Remove Provider"
+      "removeProviderAssignment": "Remove Provider",
+      "configureProxy": "Configure proxy for {{name}}"
+    },
+    "externalProxy": {
+      "title": "External Docker Proxy",
+      "description": "Configure a TCP port to expose this agent's Docker API on your network.",
+      "portLabel": "Port",
+      "portHint": "Enter a port (1024–65535) to enable, or 0 to disable.",
+      "securityWarning": "This exposes Docker API endpoints on your local network. Ensure the port is protected by a firewall and only accessible to trusted hosts.",
+      "statusLabel": "Proxy Status",
+      "statusHeading": "Current Status",
+      "statusActive": "Active",
+      "statusInactive": "Inactive",
+      "copyConnectionString": "Copy Docker connection string",
+      "reconnectNotice": "Port change will take effect on next agent reconnect.",
+      "agentOffline": "Agent is offline. Proxy status unavailable."
     }
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1229,7 +1229,22 @@
         "online": "En línea",
         "offline": "Desconectado",
         "pending": "Pendiente"
-      }
+      },
+      "configureProxy": "Configure proxy for {{name}}"
+    },
+    "externalProxy": {
+      "title": "Proxy Docker Externo",
+      "description": "Configure un puerto TCP para exponer la API Docker de este agente en su red.",
+      "portLabel": "Puerto",
+      "portHint": "Ingrese un puerto (1024–65535) para habilitar, o 0 para deshabilitar.",
+      "securityWarning": "Esto expone los endpoints de la API Docker en su red local. Asegúrese de que el puerto esté protegido por un firewall y solo sea accesible para hosts de confianza.",
+      "statusLabel": "Estado del proxy",
+      "statusHeading": "Estado actual",
+      "statusActive": "Activo",
+      "statusInactive": "Inactivo",
+      "copyConnectionString": "Copiar cadena de conexión Docker",
+      "reconnectNotice": "El cambio de puerto surtirá efecto en la próxima reconexión del agente.",
+      "agentOffline": "El agente está fuera de línea. Estado del proxy no disponible."
     }
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1229,7 +1229,22 @@
         "online": "En ligne",
         "offline": "Hors ligne",
         "pending": "En attente"
-      }
+      },
+      "configureProxy": "Configure proxy for {{name}}"
+    },
+    "externalProxy": {
+      "title": "Proxy Docker Externe",
+      "description": "Configurez un port TCP pour exposer l'API Docker de cet agent sur votre réseau.",
+      "portLabel": "Port",
+      "portHint": "Entrez un port (1024–65535) pour activer, ou 0 pour désactiver.",
+      "securityWarning": "Cela expose les points de terminaison de l'API Docker sur votre réseau local. Assurez-vous que le port est protégé par un pare-feu et accessible uniquement aux hôtes de confiance.",
+      "statusLabel": "État du proxy",
+      "statusHeading": "État actuel",
+      "statusActive": "Actif",
+      "statusInactive": "Inactif",
+      "copyConnectionString": "Copier la chaîne de connexion Docker",
+      "reconnectNotice": "La modification du port prendra effet lors de la prochaine reconnexion de l'agent.",
+      "agentOffline": "L'agent est hors ligne. État du proxy indisponible."
     }
   }
 }

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -1229,7 +1229,22 @@
         "online": "在线",
         "offline": "离线",
         "pending": "待连接"
-      }
+      },
+      "configureProxy": "Configure proxy for {{name}}"
+    },
+    "externalProxy": {
+      "title": "外部 Docker 代理",
+      "description": "配置 TCP 端口以在网络上公开此代理的 Docker API。",
+      "portLabel": "端口",
+      "portHint": "输入端口 (1024–65535) 以启用，或输入 0 以禁用。",
+      "securityWarning": "这将在您的本地网络上公开 Docker API 端点。请确保端口受防火墙保护，仅供可信主机访问。",
+      "statusLabel": "代理状态",
+      "statusHeading": "当前状态",
+      "statusActive": "活跃",
+      "statusInactive": "非活跃",
+      "copyConnectionString": "复制 Docker 连接字符串",
+      "reconnectNotice": "端口更改将在代理下次重新连接时生效。",
+      "agentOffline": "代理已离线。代理状态不可用。"
     }
   }
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -127,6 +127,7 @@ golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=
 golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
 golang.org/x/tools v0.37.0/go.mod h1:MBN5QPQtLMHVdvsbtarmTNukZDdgwdwlO5qGacAzF0w=

--- a/package-lock.json
+++ b/package-lock.json
@@ -821,9 +821,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -859,16 +859,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -877,13 +877,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.6",
+        "@vitest/spy": "4.1.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -904,9 +904,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -917,13 +917,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -931,14 +931,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -947,9 +947,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -957,13 +957,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
+        "@vitest/pretty-format": "4.1.7",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2153,9 +2153,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.46",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.46.tgz",
-      "integrity": "sha512-WHy4Coo+bGZyH7NwJKHkS04YFsFcarWbAEOAC3EMndzdN6VSZqklLLIgfxzyaW9jDoeGYJX9SWbJPKpecox0Uw==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",
@@ -3456,9 +3456,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -3476,7 +3476,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4260,19 +4260,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4300,12 +4300,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/tests/orthrus-external-proxy.spec.ts
+++ b/tests/orthrus-external-proxy.spec.ts
@@ -1,0 +1,291 @@
+import { test, expect } from './fixtures/test';
+import { waitForAPIHealth } from './utils/api-helpers';
+import { waitForLoadingComplete } from './utils/wait-helpers';
+
+const ORTHRUS_AGENTS_API = '**/api/v1/orthrus/agents';
+const ORTHRUS_AGENT_API = '**/api/v1/orthrus/agents/*';
+const ORTHRUS_PROXY_STATUS_API = '**/api/v1/orthrus/agents/*/proxy-status';
+const REMOTE_SERVERS_API = '**/api/v1/remote-servers*';
+const HECATE_STATUS_API = '**/api/v1/hecate/status*';
+
+const MOCK_AGENT_UUID = 'aaaabbbb-cccc-dddd-eeee-ffffffffffff';
+const MOCK_AGENT_NAME = 'proxy-test-agent';
+
+const MOCK_AGENT_ONLINE = {
+  uuid: MOCK_AGENT_UUID,
+  name: MOCK_AGENT_NAME,
+  status: 'online',
+  capabilities: '',
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+  external_proxy_port: 0,
+};
+
+const MOCK_AGENT_WITH_PROXY = {
+  ...MOCK_AGENT_ONLINE,
+  external_proxy_port: 2375,
+};
+
+const MOCK_PROXY_ACTIVE = {
+  agent_uuid: MOCK_AGENT_UUID,
+  configured_port: 2375,
+  agent_online: true,
+  active: true,
+  active_port: 2375,
+  bind_address: '0.0.0.0:2375',
+  connection_string: 'tcp://charon:2375',
+};
+
+const MOCK_PROXY_INACTIVE = {
+  agent_uuid: MOCK_AGENT_UUID,
+  configured_port: 0,
+  agent_online: true,
+  active: false,
+  active_port: 0,
+  bind_address: '',
+  connection_string: '',
+  error: '',
+};
+
+const MOCK_PROXY_ERROR = {
+  agent_uuid: MOCK_AGENT_UUID,
+  configured_port: 2375,
+  agent_online: true,
+  active: false,
+  active_port: 0,
+  bind_address: '',
+  connection_string: '',
+  error: 'bind tcp 0.0.0.0:2375: bind: address already in use',
+};
+
+async function setupAgentPage(
+  page: import('@playwright/test').Page,
+  agents: object[],
+  proxyStatus: object | null = null,
+) {
+  await page.route(REMOTE_SERVERS_API, (route) => route.fulfill({ json: [] }));
+  await page.route(HECATE_STATUS_API, (route) => route.fulfill({ json: [] }));
+  await page.route(ORTHRUS_AGENTS_API, (route) => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({ json: agents });
+    } else {
+      route.continue();
+    }
+  });
+  if (proxyStatus !== null) {
+    await page.route(ORTHRUS_PROXY_STATUS_API, (route) =>
+      route.fulfill({ json: proxyStatus }),
+    );
+  }
+  await page.goto('/hecate/agent');
+  await waitForLoadingComplete(page);
+}
+
+async function openProxyDialog(page: import('@playwright/test').Page, agentName: string) {
+  const configureButton = page.getByRole('button', {
+    name: new RegExp(`configure.*proxy.*${agentName}|external.*docker.*proxy.*${agentName}`, 'i'),
+  });
+  await expect(configureButton).toBeVisible({ timeout: 8000 });
+  await configureButton.click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout: 5000 });
+  return dialog;
+}
+
+test.describe('External Docker Proxy', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForAPIHealth(request);
+  });
+
+  test('configure proxy port — saves port and shows success', async ({ page }) => {
+    let patchBody: Record<string, unknown> | null = null;
+
+    await page.route(REMOTE_SERVERS_API, (route) => route.fulfill({ json: [] }));
+    await page.route(HECATE_STATUS_API, (route) => route.fulfill({ json: [] }));
+    await page.route(ORTHRUS_AGENTS_API, (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({ json: [MOCK_AGENT_ONLINE] });
+      } else {
+        route.continue();
+      }
+    });
+    await page.route(ORTHRUS_PROXY_STATUS_API, (route) => route.fulfill({ json: MOCK_PROXY_INACTIVE }));
+    await page.route(ORTHRUS_AGENT_API, async (route) => {
+      if (route.request().method() === 'PATCH') {
+        patchBody = await route.request().postDataJSON() as Record<string, unknown>;
+        route.fulfill({ json: { ...MOCK_AGENT_ONLINE, external_proxy_port: 2376 } });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto('/hecate/agent');
+    await waitForLoadingComplete(page);
+
+    const dialog = await openProxyDialog(page, MOCK_AGENT_NAME);
+
+    await test.step('Enter port 2376', async () => {
+      const portInput = dialog.locator('#external-proxy-port');
+      await expect(portInput).toBeVisible({ timeout: 5000 });
+      await portInput.fill('2376');
+    });
+
+    await test.step('Click Save and verify API call', async () => {
+      const saveButton = dialog.getByRole('button', { name: /save/i });
+      await saveButton.click();
+
+      await expect(dialog).not.toBeVisible({ timeout: 8000 });
+      expect(patchBody).toBeTruthy();
+      expect(patchBody?.external_proxy_port).toBe(2376);
+    });
+  });
+
+  test('disable proxy — set port to 0', async ({ page }) => {
+    let patchBody: Record<string, unknown> | null = null;
+
+    await page.route(REMOTE_SERVERS_API, (route) => route.fulfill({ json: [] }));
+    await page.route(HECATE_STATUS_API, (route) => route.fulfill({ json: [] }));
+    await page.route(ORTHRUS_AGENTS_API, (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({ json: [MOCK_AGENT_WITH_PROXY] });
+      } else {
+        route.continue();
+      }
+    });
+    await page.route(ORTHRUS_PROXY_STATUS_API, (route) => route.fulfill({ json: MOCK_PROXY_ACTIVE }));
+    await page.route(ORTHRUS_AGENT_API, async (route) => {
+      if (route.request().method() === 'PATCH') {
+        patchBody = await route.request().postDataJSON() as Record<string, unknown>;
+        route.fulfill({ json: { ...MOCK_AGENT_WITH_PROXY, external_proxy_port: 0 } });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto('/hecate/agent');
+    await waitForLoadingComplete(page);
+
+    const dialog = await openProxyDialog(page, MOCK_AGENT_NAME);
+
+    await test.step('Clear port and set to 0', async () => {
+      const portInput = dialog.locator('#external-proxy-port');
+      await portInput.fill('0');
+    });
+
+    await test.step('Save and verify port 0 sent to API', async () => {
+      const saveButton = dialog.getByRole('button', { name: /save/i });
+      await saveButton.click();
+      await expect(dialog).not.toBeVisible({ timeout: 8000 });
+      expect(patchBody?.external_proxy_port).toBe(0);
+    });
+  });
+
+  test('invalid port rejected — client-side validation prevents API call', async ({ page }) => {
+    let apiCalled = false;
+
+    await setupAgentPage(page, [MOCK_AGENT_ONLINE], MOCK_PROXY_INACTIVE);
+    await page.route(ORTHRUS_AGENT_API, (route) => {
+      if (route.request().method() === 'PATCH') {
+        apiCalled = true;
+      }
+      route.continue();
+    });
+
+    const dialog = await openProxyDialog(page, MOCK_AGENT_NAME);
+
+    await test.step('Enter privileged port 80', async () => {
+      const portInput = dialog.locator('#external-proxy-port');
+      await portInput.fill('80');
+    });
+
+    await test.step('Save button is disabled and alert shown for invalid port', async () => {
+      const saveButton = dialog.getByRole('button', { name: /save/i });
+      await expect(saveButton).toBeDisabled();
+
+      const error = dialog.locator('[role="alert"]');
+      await expect(error).toBeVisible({ timeout: 3000 });
+      await expect(error).toContainText(/1024/);
+      expect(apiCalled).toBe(false);
+    });
+
+    await test.step('Dialog remains open after validation error', async () => {
+      await expect(dialog).toBeVisible();
+    });
+  });
+
+  test('connection string displayed when agent online with active proxy', async ({ page }) => {
+    await setupAgentPage(page, [MOCK_AGENT_WITH_PROXY], MOCK_PROXY_ACTIVE);
+
+    const dialog = await openProxyDialog(page, MOCK_AGENT_NAME);
+
+    await test.step('Connection string is visible', async () => {
+      await expect(dialog.getByText('tcp://charon:2375')).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step('Copy button is present with accessible label', async () => {
+      const copyButton = dialog.getByRole('button', {
+        name: /copy docker connection string/i,
+      });
+      await expect(copyButton).toBeVisible();
+    });
+
+    await test.step('Active status indicator is shown', async () => {
+      // Status region uses role=status with aria-live
+      const statusRegion = dialog.locator('[role="status"]');
+      await expect(statusRegion).toBeVisible();
+      await expect(statusRegion).toContainText(/active/i);
+    });
+  });
+
+  test('reconnect notice shown when configured port differs from active port', async ({ page }) => {
+    // Agent has external_proxy_port=2376 (saved in DB) but proxy is still
+    // running on 2375 (active_port). The form initialises to 2376, so
+    // active_port(2375) !== portValue(2376) → reconnect notice is shown.
+    const divergedAgent = { ...MOCK_AGENT_WITH_PROXY, external_proxy_port: 2376 };
+    const divergedStatus = {
+      ...MOCK_PROXY_ACTIVE,
+      configured_port: 2376,
+      active_port: 2375,
+    };
+
+    await setupAgentPage(page, [divergedAgent], divergedStatus);
+
+    const dialog = await openProxyDialog(page, MOCK_AGENT_NAME);
+
+    await test.step('Reconnect notice is visible', async () => {
+      await expect(
+        dialog.getByText(/next agent reconnect/i),
+      ).toBeVisible({ timeout: 5000 });
+    });
+  });
+
+  test('error state displayed when bind fails', async ({ page }) => {
+    await setupAgentPage(page, [MOCK_AGENT_WITH_PROXY], MOCK_PROXY_ERROR);
+
+    const dialog = await openProxyDialog(page, MOCK_AGENT_NAME);
+
+    await test.step('Error message is displayed with role=alert', async () => {
+      const errorAlert = dialog.locator('[role="alert"]');
+      await expect(errorAlert).toBeVisible({ timeout: 5000 });
+      await expect(errorAlert).toContainText(/address already in use/i);
+    });
+  });
+
+  test('PROXY badge appears in agent row when external_proxy_port > 0', async ({ page }) => {
+    await setupAgentPage(page, [MOCK_AGENT_WITH_PROXY], null);
+
+    await test.step('PROXY badge is visible in agent row', async () => {
+      const proxyBadge = page.getByText('PROXY', { exact: true });
+      await expect(proxyBadge).toBeVisible({ timeout: 8000 });
+    });
+  });
+
+  test('PROXY badge absent when external_proxy_port is 0', async ({ page }) => {
+    await setupAgentPage(page, [MOCK_AGENT_ONLINE], null);
+
+    await test.step('PROXY badge is not visible', async () => {
+      const proxyBadge = page.getByText('PROXY', { exact: true });
+      await expect(proxyBadge).not.toBeVisible({ timeout: 5000 });
+    });
+  });
+});


### PR DESCRIPTION
## Problem

After switching a `RemoteServer` to use an Orthrus agent instead of a generic `socat` socket proxy, all Docker operations through that server return 502:

> Cannot connect to Docker. Please ensure Docker is running and the socket is accessible.

**Root cause**: The Orthrus agent already handles `streamTypeDocker = 0x01` — when the server opens a yamux stream with that type byte, the agent bridges it to its local `/var/run/docker.sock`. However, the server-side was a stub: `proxyPort` was never set in production, so `GetProxyAddr()` always returned `("", false)`. The Docker handler had no valid address to route requests through and fell back to a dead `tcp://host:port`.

---

## What This PR Does

### `backend/internal/orthrus/session.go`

- **`StartDockerProxy()`** — binds an ephemeral `127.0.0.1:0` TCP listener on agent connect; double-checked locking prevents concurrent races; `IsClosed()` guard prevents allocation on dead sessions
- **`runProxyListener()`** — accept loop; exits cleanly on `net.ErrClosed`
- **`proxyConn()`** — for each accepted TCP connection: opens a yamux stream, writes type byte `0x01`, bidirectionally copies via two `io.Copy` goroutines + `sync.WaitGroup`
- **`Close()`** — closes the listener under mutex before closing the yamux session, ensuring the accept goroutine exits via `net.ErrClosed` rather than leaking

### `backend/internal/orthrus/server.go`

- **`HandleWebSocket`** — calls `sess.StartDockerProxy()` after `NewAgentSession`, before storing the session; failure is non-fatal (logs warn) so a transient OS resource pressure won't reject a connecting agent
- **`watchHeartbeat`** — calls `sess.Close()` when the yamux session dies, stopping the `runProxyListener` goroutine and freeing the port before `markOffline` runs (without this, the goroutine and file descriptor would leak until GC)

Also includes the previously-merged typed-nil interface fix:

### `backend/internal/api/handlers/docker_handler.go` + `routes/routes.go`

- Guard in `routes.go` prevents a `nil *OrthrusServer` from being boxed into a non-nil interface
- Reflect-based nil normalization in `SetOrthrusResolver` as a defence-in-depth second layer

---

## Tests

**5 new unit tests** (`session_proxy_test.go`) — all pass with `-race`:

| Test | Covers |
|------|--------|
| `TestStartDockerProxy_SetsProxyAddr` | Listener bound, address returned |
| `TestStartDockerProxy_Idempotent` | Second call returns error, address unchanged |
| `TestStartDockerProxy_AcceptsAndForwards` | TCP connection → yamux stream → `0x01` type byte → bidirectional copy |
| `TestClose_StopsProxyListener` | Listener closed on `sess.Close()` |
| `TestStartDockerProxy_AfterClose` | Start on closed session returns error |

**2 new server integration tests** (`server_proxy_test.go`):

| Test | Covers |
|------|--------|
| `TestHandleWebSocket_StartsProxyOnConnect` | Proxy addr non-empty after agent connects |
| `TestWatchHeartbeat_StopsProxyOnSessionDeath` | Listener closed when heartbeat detects dead session |

**Coverage**: 89.4% statements — above the 85% gate. Race detector: clean.

---

## Security Notes

- TCP listener is bound exclusively to `127.0.0.1` — never exposed outside the host
- Ephemeral port (`:0`) — no fixed port to block or exploit
- Agent-side `muzzle` filter restricts allowed Docker API paths — unchanged
- No credentials in proxy stream; authentication is at the WebSocket layer
