### PR TITLE
fix(frontend): remove deprecated Firefox CSS and add modern browserslist targets

### DIFF
--- a/frontend/.browserslistrc
+++ b/frontend/.browserslistrc
@@ -1,0 +1,5 @@
+> 0.5%
+last 2 versions
+Firefox ESR
+not dead
+not IE 11

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -225,7 +225,6 @@
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary

- Remove `-moz-osx-font-smoothing: grayscale` from `frontend/src/index.css` — Firefox has never supported this property; it was a no-op generating a console warning. `-webkit-font-smoothing` already handles Chrome/Safari font smoothing.
- Add `frontend/.browserslistrc` targeting modern browsers (> 0.5%, last 2 versions, Firefox ESR, not dead, not IE 11) so autoprefixer stops generating legacy `-moz-` vendor prefixes for properties that modern Firefox supports natively.

**Root cause analysis:** The hundreds of `dropdown.css` errors in the Firefox console are from a **browser extension** (likely a password manager injecting its own CSS), not from this codebase — confirmed by exhaustive search across all source and dist files. Those are not actionable.

## Test plan

- [x] Frontend build passes (`tsc -p tsconfig.build.json && vite build`) — exit 0 confirmed
- [x] Built CSS verified: `-moz-osx-font-smoothing` eliminated from output
- [x] Remaining `-moz-column-gap` occurrence is from Tailwind's `.gap-x-*` utility (upstream, both prefixed + unprefixed forms present, no visual impact)
- [ ] CI: Playwright E2E, frontend unit tests, coverage checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)