### PR TITLE
fix(assets): serve banner.webp and use picture element for optimized image delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,4 @@ backend/***_cov.txt
 .tmp/***
 charon-scan.tar
 .claude/scheduled_tasks.lock
+.claude/worktrees/

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -21,7 +21,11 @@ func NewRouter(frontendDir string) *gin.Engine {
 		router.Static("/assets", frontendDir+"/assets")
 		router.StaticFile("/", frontendDir+"/index.html")
 		router.StaticFile("/banner.png", frontendDir+"/banner.png")
+		router.StaticFile("/banner.webp", frontendDir+"/banner.webp")
+		router.StaticFile("/banner.svg", frontendDir+"/banner.svg")
 		router.StaticFile("/logo.png", frontendDir+"/logo.png")
+		router.StaticFile("/logo.webp", frontendDir+"/logo.webp")
+		router.StaticFile("/logo.svg", frontendDir+"/logo.svg")
 		router.StaticFile("/favicon.png", frontendDir+"/favicon.png")
 		router.NoRoute(func(c *gin.Context) {
 			// API routes should never fall back to the SPA HTML.

--- a/backend/internal/server/server_test.go
+++ b/backend/internal/server/server_test.go
@@ -37,4 +37,19 @@ func TestNewRouter(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, apiW.Code)
 	assert.NotContains(t, apiW.Body.String(), "<html></html>")
 	assert.Contains(t, apiW.Body.String(), "not found")
+
+	// Test WebP/SVG static routes return 200 when the file exists
+	for _, asset := range []struct{ route, file string }{
+		{"/banner.webp", "banner.webp"},
+		{"/banner.svg", "banner.svg"},
+		{"/logo.webp", "logo.webp"},
+		{"/logo.svg", "logo.svg"},
+	} {
+		// #nosec G306 -- Test fixture needs to be world-readable for HTTP serving test
+		_ = os.WriteFile(filepath.Join(tempDir, asset.file), []byte("data"), 0o644)
+		r, _ := http.NewRequest("GET", asset.route, http.NoBody)
+		rw := httptest.NewRecorder()
+		router.ServeHTTP(rw, r)
+		assert.Equal(t, http.StatusOK, rw.Code, "route %s should return 200", asset.route)
+	}
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -167,7 +167,10 @@ export default function Layout({ children }: LayoutProps) {
            {isCollapsed ? (
              <img src="/logo.png" alt="Charon" className="h-12 w-auto" fetchPriority="high" decoding="async" />
            ) : (
-             <img src="/banner.png" alt="Charon" className="h-14 w-auto max-w-[200px] object-contain" fetchPriority="high" decoding="async" />
+             <picture>
+               <source srcSet="/banner.webp" type="image/webp" />
+               <img src="/banner.png" alt="Charon" className="h-14 w-auto max-w-[200px] object-contain" fetchPriority="high" decoding="async" />
+             </picture>
            )}
         </div>
 

--- a/frontend/src/components/__tests__/Layout.test.tsx
+++ b/frontend/src/components/__tests__/Layout.test.tsx
@@ -90,6 +90,30 @@ describe('Layout', () => {
     expect(logos[0]).toBeInTheDocument()
   })
 
+  it('renders banner inside a picture element with webp source when sidebar is expanded', () => {
+    localStorage.setItem('sidebarCollapsed', 'false')
+    renderWithProviders(
+      <Layout>
+        <div>Test Content</div>
+      </Layout>
+    )
+
+    const pictures = document.querySelectorAll('picture')
+    expect(pictures.length).toBeGreaterThan(0)
+
+    const sources = document.querySelectorAll('picture source')
+    expect(sources.length).toBeGreaterThan(0)
+    const webpSource = Array.from(sources).find(
+      (s) => s.getAttribute('type') === 'image/webp'
+    )
+    expect(webpSource).toBeTruthy()
+    expect(webpSource?.getAttribute('srcset')).toBe('/banner.webp')
+
+    const bannerImg = document.querySelector('picture img')
+    expect(bannerImg).toBeTruthy()
+    expect(bannerImg?.getAttribute('src')).toBe('/banner.png')
+  })
+
   it('renders all navigation items', async () => {
     const user = userEvent.setup()
     renderWithProviders(


### PR DESCRIPTION
## Summary

- Adds missing static routes in `backend/internal/server/server.go` for `/banner.webp`, `/banner.svg`, `/logo.webp`, and `/logo.svg` — these previously fell through to `index.html`, causing `NS_BINDING_ABORTED` for the 1.2 MB `/banner.png`
- Replaces the bare `<img src="/banner.png">` in `frontend/src/components/Layout.tsx` with a `<picture>` element that serves the existing `banner.webp` (304 KB, 74% smaller) to capable browsers with PNG as a fallback
- Adds tests for all 4 new backend routes and the updated `<picture>` structure in Layout

## Test plan

- [x] Backend unit tests: all 12 pass (4 new route assertions)
- [x] Frontend unit tests: all 17 pass (1 new `<picture>` assertion)
- [x] Playwright E2E (Firefox): 767 passed, 37 skipped, 0 failed
- [x] Backend coverage: 88.6% (gate: 87%)
- [x] Frontend coverage: 88.4% statements / 89.4% lines (gate: 85%)
- [x] Patch coverage: 100%
- [x] `npm run type-check`: zero errors
- [x] Frontend build: successful
- [x] Backend build: successful
- [x] `lefthook run pre-commit`: zero errors
- [x] `make lint-fast`: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)