### PR TITLE
fix(security): prepare for npm v12 breaking changes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -227,6 +227,19 @@
     },
     {
       "customType": "regex",
+      "description": "Track NODE_VERSION in Actions workflows",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.*\\.yml$/"
+      ],
+      "matchStrings": [
+        "NODE_VERSION: ['\"]?(?<currentValue>[\\d\\.]+)['\"]?"
+      ],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    },
+    {
+      "customType": "regex",
       "description": "Track GO_VERSION in Actions workflows",
       "managerFilePatterns": [
         "/^\\.github/workflows/.*\\.yml$/"

--- a/.github/skills/test-e2e-playwright-coverage-scripts/run.sh
+++ b/.github/skills/test-e2e-playwright-coverage-scripts/run.sh
@@ -158,7 +158,7 @@ start_vite() {
     # Ensure dependencies are installed
     if [[ ! -d "node_modules" ]]; then
         log_info "Installing frontend dependencies..."
-        npm ci --silent
+        npm ci --silent --ignore-scripts
     fi
 
     # Start Vite in background with explicit port

--- a/.github/workflows/codecov-upload.yml
+++ b/.github/workflows/codecov-upload.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontend
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Run frontend tests and coverage
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/e2e-tests-split.yml
+++ b/.github/workflows/e2e-tests-split.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.resolve-image.outputs.image_source == 'build'
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Set up Docker Buildx
         if: steps.resolve-image.outputs.image_source == 'build'
@@ -304,7 +304,7 @@ jobs:
           exit 1
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium
         run: |
@@ -506,7 +506,7 @@ jobs:
           exit 1
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
         run: |
@@ -716,7 +716,7 @@ jobs:
           exit 1
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
         run: |
@@ -953,7 +953,7 @@ jobs:
           exit 1
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium
         run: |
@@ -1191,7 +1191,7 @@ jobs:
           exit 1
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
         run: |
@@ -1437,7 +1437,7 @@ jobs:
           exit 1
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
         run: |

--- a/.github/workflows/e2e-tests-split.yml
+++ b/.github/workflows/e2e-tests-split.yml
@@ -82,7 +82,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '24.12.0'
   GO_VERSION: '1.26.4'
   GOTOOLCHAIN: local
   DOCKERHUB_REGISTRY: docker.io

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -310,7 +310,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontend
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Run frontend tests and coverage
         id: frontend-tests

--- a/.github/workflows/release-goreleaser.yml
+++ b/.github/workflows/release-goreleaser.yml
@@ -62,7 +62,7 @@ jobs:
           # Inject version into frontend build from tag (if present)
           VERSION=${GITHUB_REF#refs/tags/}
           echo "VITE_APP_VERSION=${VERSION}" >> "$GITHUB_ENV"
-          npm ci
+          npm ci --ignore-scripts
           npm run build
 
       - name: Install Cross-Compilation Tools (Zig)

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN apk upgrade --no-cache && \
 # hadolint ignore=DL3059
 RUN npm install -g picomatch@4.0.4 --no-fund --no-audit
 
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 # Copy frontend source and build
 COPY frontend/ ./

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install:
 	@echo "Installing backend dependencies..."
 	cd backend && go mod download
 	@echo "Installing frontend dependencies..."
-	cd frontend && npm install
+	cd frontend && npm install --ignore-scripts
 
 # Install Go development tools
 install-tools:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -p tsconfig.build.json && vite build",
-    "pretype-check": "npm ci --silent",
+    "pretype-check": "npm ci --silent --ignore-scripts",
     "type-check": "tsc --noEmit",
     "lint": "eslint . --report-unused-disable-directives",
     "preview": "vite preview",
@@ -18,7 +18,7 @@
     "test:ci": "NODE_OPTIONS=--max-old-space-size=4096 vitest run",
     "test:ui": "vitest --ui",
     "check-coverage": "bash ../scripts/frontend-test-coverage.sh",
-    "pretest:coverage": "npm ci --silent && node -e \"require('fs').mkdirSync('coverage/.tmp', { recursive: true })\"",
+    "pretest:coverage": "npm ci --silent --ignore-scripts && node -e \"require('fs').mkdirSync('coverage/.tmp', { recursive: true })\"",
     "test:coverage": "NODE_OPTIONS=--max-old-space-size=4096 vitest run --coverage",
     "e2e:install": "npx playwright install --with-deps",
     "e2e:test": "playwright test",
@@ -114,5 +114,8 @@
     "@vitejs/plugin-react": {
       "vite": "^8.0.16"
     }
+  },
+  "allowScripts": {
+    "unrs-resolver": false
   }
 }

--- a/scripts/frontend-test-coverage.sh
+++ b/scripts/frontend-test-coverage.sh
@@ -19,7 +19,7 @@ RUN_COVERAGE_DIR="coverage/.run-${PPID}-$$-$(date +%s)"
 cd "$FRONTEND_DIR"
 
 # Ensure dependencies are installed for CI runs
-npm ci --silent
+npm ci --silent --ignore-scripts
 
 # Ensure coverage output directories exist
 mkdir -p "$CANONICAL_COVERAGE_DIR"

--- a/scripts/npm_update.sh
+++ b/scripts/npm_update.sh
@@ -20,7 +20,7 @@ for MODULE in "${MODULES[@]}"; do
 
     npx npm-check-updates -u
     rm -rf node_modules package-lock.json
-    npm install
+    npm install --ignore-scripts
     npm dedupe
     npm run --if-present build
     npm audit --audit-level=high

--- a/scripts/setup-e2e-env.sh
+++ b/scripts/setup-e2e-env.sh
@@ -126,7 +126,7 @@ echo ""
 
 # Step 2: Install npm dependencies
 echo -e "${BLUE}📦 Step 2: Installing npm dependencies...${NC}"
-npm ci --silent
+npm ci --silent --ignore-scripts
 echo -e "${GREEN}✅ Dependencies installed${NC}"
 echo ""
 


### PR DESCRIPTION
## Summary

npm v12 (expected ~July 2026) disables dependency install scripts and blocks git/remote-URL dependencies by default ([announcement](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/)). This PR adopts those secure defaults today so the eventual Renovate `NPM_VERSION` 11→12 bump is a non-event.

- **Node 20 → 24.12.0** in `e2e-tests-split.yml` (Node 20 is EOL and likely unsupported by npm 12), matching all other workflows
- **New Renovate custom manager** tracking `NODE_VERSION` in all workflows (previously unmanaged — only `GO_VERSION` was tracked)
- **`--ignore-scripts` on every npm install call site**: CI workflows, Dockerfile, Makefile, helper scripts, and `package.json` pre-hooks
- **Explicit `allowScripts` denial of `unrs-resolver`'s postinstall** in `frontend/package.json` — it ships prebuilt binaries via optionalDependencies; the script is only a fallback build. `npm approve-scripts --allow-scripts-pending` now reports zero unreviewed packages

The flag lives on install commands rather than a checked-in `.npmrc` because `ignore-scripts=true` in npmrc would also suppress the project's own `pre*` run-script hooks (`pretype-check`, `pretest:coverage`).

## Verification (local, npm 11.16.0 which enforces v12 `allowScripts` semantics)

- `npm ci --ignore-scripts` clean in root and `frontend/`, zero vulnerabilities, no git/remote-dep warnings
- Frontend build, type-check, and full unit suite pass (2563 passed / 0 failed)
- `renovate-config-validator` passes
- Audit confirmed both lockfiles are v3, registry-only resolved URLs (no git/tarball deps to remediate)

## Follow-ups (not in this PR)

- Add `engines` fields to root and frontend `package.json`
- Treat the future Renovate npm 11→12 bump PR as behavior-changing: verify the Docker build before merging