### PR TITLE
feat(logs): sortable log table with hardened query and download API

### DIFF
--- a/.claude/agents/planning.md
+++ b/.claude/agents/planning.md
@@ -67,5 +67,5 @@ You are a PRINCIPAL ARCHITECT responsible for technical planning and system desi
 - **DETAILED SPECS**: Plans must include specific file paths, function signatures, and API schemas.
 - **NO IMPLEMENTATION**: Do not write implementation code, only specifications.
 - **CONSIDER EDGE CASES**: Document error handling and edge cases.
-- **SLICE FOR SPEED**: Prefer multiple small PRs when it improves review quality, delivery speed, or rollback safety.
+- **SLICE COMMITS, NOT PRs**: One feature = one PR, merged only when complete. Never propose splitting a feature across multiple PRs; improve reviewability through small, ordered, logical commits within the single PR.
 </constraints>

--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -140,20 +140,17 @@ Before proposing ANY code change or fix, you must build a mental map of the feat
 - **Beta**: `feature/beta-release` always builds.
 - **History-Rewrite PRs**: If a PR touches files in `scripts/history-rewrite/` or `docs/plans/history_rewrite.md`, the PR description MUST include the history-rewrite checklist from `.github/PULL_REQUEST_TEMPLATE/history-rewrite.md`. This is enforced by CI.
 
-## PR Sizing & Decomposition
+## Commit Slicing & PR Strategy
 
-- **Default Rule**: Prefer smaller, reviewable PRs over one large PR when work spans multiple domains.
-- **Split into Multiple PRs When**:
-    - The change touches backend + frontend + infrastructure/security in one effort
-    - The estimated diff is large enough to reduce review quality or increase rollback risk
-    - The work can be delivered in independently testable slices without breaking behavior
-    - A foundational refactor is needed before feature delivery
-- **Suggested PR Sequence**:
-    1. Foundation PR (types/contracts/refactors, no behavior change)
-    2. Backend PR (API/model/service changes + tests)
-    3. Frontend PR (UI integration + tests)
-    4. Hardening PR (security/CI/docs/follow-up fixes)
-- **Per-PR Requirement**: Every PR must remain deployable, pass DoD checks, and include a clear dependency note on prior PRs.
+- **One Feature = One PR**: A feature merges only when it is complete. NEVER split a single feature across multiple PRs (e.g., separate backend/frontend/security PRs) — plans must produce a **Commit Slicing Strategy**, not a PR slicing strategy.
+- **Slice Commits, Not PRs**: Decompose the work into ordered, logical commits within the single feature PR. Each commit defines its scope, files, dependencies, and validation gate.
+- **Suggested Commit Sequence** within the PR:
+    1. E2E specs for new behavior (as `test.fixme` until implemented)
+    2. Foundation (types/contracts/refactors, no behavior change)
+    3. Backend (API/model/service changes + tests)
+    4. Frontend (UI integration + tests)
+    5. Hardening + enable E2E + docs
+- **Per-Commit Requirement**: Each commit should build and pass its validation gate; the PR as a whole must pass the full Definition of Done before merge.
 
 ## ✅ Task Completion Protocol (Definition of Done)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,16 +103,17 @@ Before proposing ANY code change or fix, build a mental map of the feature:
 - **Weekly Promotion PRs** (`nightly → main`): ALWAYS merge using **"Create a merge commit"** — NEVER squash or rebase. Squash merging collapses all commits into bullet lines that the `auto-versioning` workflow cannot parse, silently preventing minor version bumps and producing empty release notes.
 - **History-Rewrite PRs**: If a PR touches files in `scripts/history-rewrite/` or `docs/plans/history_rewrite.md`, the PR description MUST include the history-rewrite checklist from `.github/PULL_REQUEST_TEMPLATE/history-rewrite.md`.
 
-## PR Sizing & Decomposition
+## Commit Slicing & PR Strategy
 
-- **Default Rule**: Prefer smaller, reviewable PRs over one large PR when work spans multiple domains.
-- **Split into Multiple PRs When**: the change touches backend + frontend + infrastructure/security; the diff is large enough to reduce review quality; work can be delivered in independently testable slices; a foundational refactor is needed before feature delivery.
-- **Suggested PR Sequence**:
-  1. Foundation PR (types/contracts/refactors, no behavior change)
-  2. Backend PR (API/model/service changes + tests)
-  3. Frontend PR (UI integration + tests)
-  4. Hardening PR (security/CI/docs/follow-up fixes)
-- **Per-PR Requirement**: Every PR must remain deployable, pass DoD checks, and include a clear dependency note on prior PRs.
+- **One Feature = One PR**: A feature merges only when it is complete. NEVER split a single feature across multiple PRs (e.g., separate backend/frontend/security PRs) — plans must produce a **Commit Slicing Strategy**, not a PR slicing strategy.
+- **Slice Commits, Not PRs**: Decompose the work into ordered, logical commits within the single feature PR. Each commit defines its scope, files, dependencies, and validation gate.
+- **Suggested Commit Sequence** within the PR:
+  1. E2E specs for new behavior (as `test.fixme` until implemented)
+  2. Foundation (types/contracts/refactors, no behavior change)
+  3. Backend (API/model/service changes + tests)
+  4. Frontend (UI integration + tests)
+  5. Hardening + enable E2E + docs
+- **Per-Commit Requirement**: Each commit should build and pass its validation gate; the PR as a whole must pass the full Definition of Done before merge.
 
 ## ✅ Task Completion Protocol (Definition of Done)
 

--- a/backend/internal/api/handlers/logs_handler.go
+++ b/backend/internal/api/handlers/logs_handler.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/Wikid82/charon/backend/internal/logger"
 	"github.com/Wikid82/charon/backend/internal/models"
@@ -47,6 +46,10 @@ func (h *LogsHandler) Read(c *gin.Context) {
 
 	logs, total, skipped, err := h.service.QueryLogs(filename, filter)
 	if err != nil {
+		if errors.Is(err, services.ErrInvalidFilename) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 		if errors.Is(err, os.ErrNotExist) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Log file not found"})
 			return
@@ -69,7 +72,7 @@ func (h *LogsHandler) Download(c *gin.Context) {
 	filename := c.Param("filename")
 	path, err := h.service.GetLogPath(filename)
 	if err != nil {
-		if strings.Contains(err.Error(), "invalid filename") {
+		if errors.Is(err, services.ErrInvalidFilename) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
@@ -90,8 +93,11 @@ func (h *LogsHandler) Download(c *gin.Context) {
 		}
 	}()
 
-	// #nosec G304 -- path is validated via LogService.GetLogPath which enforces
-	// filepath.Base equality check and path prefix validation.
+	// #nosec G304 -- path is the symlink-RESOLVED location returned by
+	// LogService.GetLogPath, which enforces filepath.Base equality, a raw
+	// directory-entry allowlist, and both-sides EvalSymlinks containment
+	// inside the configured log directories; opening the resolved path closes
+	// the TOCTOU window between validation and open.
 	srcFile, err := os.Open(path) //nolint:gosec // nosemgrep: go.gin.path-traversal.gin-path-traversal-taint.gin-path-traversal-taint
 	if err != nil {
 		if err := tmpFile.Close(); err != nil {
@@ -117,6 +123,8 @@ func (h *LogsHandler) Download(c *gin.Context) {
 		logger.Log().WithError(err).Warn("failed to close temp file after copy")
 	}
 
-	c.Header("Content-Disposition", "attachment; filename="+filename)
-	c.File(tmpFile.Name())
+	// Explicit text/plain prevents HTML content-sniffing of attacker-influenced
+	// log content; FileAttachment emits an RFC 6266 quoted Content-Disposition.
+	c.Header("Content-Type", "text/plain; charset=utf-8")
+	c.FileAttachment(tmpFile.Name(), filename)
 }

--- a/backend/internal/api/handlers/logs_handler.go
+++ b/backend/internal/api/handlers/logs_handler.go
@@ -1,10 +1,10 @@
 package handlers
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/Wikid82/charon/backend/internal/logger"
@@ -35,23 +35,19 @@ func (h *LogsHandler) List(c *gin.Context) {
 func (h *LogsHandler) Read(c *gin.Context) {
 	filename := c.Param("filename")
 
-	// Parse query parameters
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
-
-	filter := models.LogFilter{
-		Search: c.Query("search"),
-		Host:   c.Query("host"),
-		Status: c.Query("status"),
-		Level:  c.Query("level"),
-		Limit:  limit,
-		Offset: offset,
-		Sort:   c.DefaultQuery("sort", "desc"),
+	var filter models.LogFilter
+	if err := c.ShouldBindQuery(&filter); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid query parameters: " + err.Error()})
+		return
+	}
+	if err := filter.Validate(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
 	}
 
-	logs, total, err := h.service.QueryLogs(filename, filter)
+	logs, total, skipped, err := h.service.QueryLogs(filename, filter)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Log file not found"})
 			return
 		}
@@ -60,11 +56,12 @@ func (h *LogsHandler) Read(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"filename": filename,
-		"logs":     logs,
-		"total":    total,
-		"limit":    limit,
-		"offset":   offset,
+		"filename":      filename,
+		"logs":          logs,
+		"total":         total,
+		"limit":         filter.Limit,
+		"offset":        filter.Offset,
+		"skipped_lines": skipped,
 	})
 }
 

--- a/backend/internal/api/handlers/logs_handler_test.go
+++ b/backend/internal/api/handlers/logs_handler_test.go
@@ -144,6 +144,126 @@ func TestLogsLifecycle(t *testing.T) {
 	require.Empty(t, emptyLogs)
 }
 
+func TestRead_SortByParam(t *testing.T) {
+	router, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Fixture has status 200 (ts=1600000000) and 500 (ts=1600000060).
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/access.log?sort_by=status&sort=asc", http.NoBody)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var body struct {
+		Logs []struct {
+			Status int `json:"status"`
+		} `json:"logs"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	require.Len(t, body.Logs, 2)
+	require.Equal(t, 200, body.Logs[0].Status)
+	require.Equal(t, 500, body.Logs[1].Status)
+
+	// Same field descending.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/logs/access.log?sort_by=status&sort=desc", http.NoBody)
+	resp = httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	require.Len(t, body.Logs, 2)
+	require.Equal(t, 500, body.Logs[0].Status)
+}
+
+func TestRead_InvalidSortBy(t *testing.T) {
+	router, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/access.log?sort_by=password", http.NoBody)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	require.Equal(t, "invalid sort_by: must be one of ts, level, method, uri, status", body.Error)
+}
+
+func TestRead_SkippedLinesInResponse(t *testing.T) {
+	router, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// One valid JSON line, one corrupted line (NUL byte, not valid JSON).
+	logsDir := filepath.Join(tmpDir, "data", "logs")
+	content := "{\"level\":\"info\",\"ts\":1,\"msg\":\"ok\"}\ncorrupt\x00line\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "corrupt.log"), []byte(content), 0o600)) // #nosec G306 -- test fixture
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/corrupt.log", http.NoBody)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var body struct {
+		Total        int64 `json:"total"`
+		SkippedLines int64 `json:"skipped_lines"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	require.Equal(t, int64(1), body.Total)
+	require.Equal(t, int64(1), body.SkippedLines)
+}
+
+// Compat pin (spec §5.1.2 change 1): non-numeric limit was silently discarded
+// (empty page); it is now an explicit 400.
+func TestRead_LimitNonNumeric_Returns400(t *testing.T) {
+	router, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/access.log?limit=abc", http.NoBody)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+	require.Contains(t, resp.Body.String(), "error")
+}
+
+// Compat pin (spec §5.1.2 change 2): limit=0 used to produce an empty page;
+// it is now treated as unset and defaults to 50.
+func TestRead_LimitZero_DefaultsTo50(t *testing.T) {
+	router, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/access.log?limit=0", http.NoBody)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var body struct {
+		Limit int   `json:"limit"`
+		Total int64 `json:"total"`
+		Logs  []any `json:"logs"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	require.Equal(t, 50, body.Limit)
+	require.Len(t, body.Logs, 2)
+}
+
+func TestRead_LimitClampedTo500(t *testing.T) {
+	router, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/access.log?limit=9999", http.NoBody)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var body struct {
+		Limit int `json:"limit"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	require.Equal(t, 500, body.Limit)
+}
+
 func TestLogsHandler_PathTraversal(t *testing.T) {
 	_, tmpDir := setupLogsTest(t)
 	defer func() { _ = os.RemoveAll(tmpDir) }()

--- a/backend/internal/api/handlers/logs_handler_test.go
+++ b/backend/internal/api/handlers/logs_handler_test.go
@@ -284,3 +284,103 @@ func TestLogsHandler_PathTraversal(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 	require.Contains(t, w.Body.String(), "invalid filename")
 }
+
+// Sentinel mapping (spec §5.3.2): the service returns a wrapped
+// ErrInvalidFilename and the Read handler maps it via errors.Is -> 400
+// (no string matching).
+func TestRead_InvalidFilename_400_ViaErrorsIs(t *testing.T) {
+	_, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "filename", Value: "../access.log"}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/logs/x", http.NoBody)
+
+	svc := services.NewLogService(&config.Config{DatabasePath: filepath.Join(tmpDir, "data", "charon.db")})
+	h := NewLogsHandler(svc)
+
+	h.Read(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "invalid filename")
+}
+
+func TestDownload_InvalidFilename_400_ViaErrorsIs(t *testing.T) {
+	_, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "filename", Value: "..%2Fsecret"}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/logs/x/download", http.NoBody)
+
+	svc := services.NewLogService(&config.Config{DatabasePath: filepath.Join(tmpDir, "data", "charon.db")})
+	h := NewLogsHandler(svc)
+
+	h.Download(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "invalid filename")
+}
+
+func TestDownload_ContentDispositionQuoted(t *testing.T) {
+	router, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/access.log/download", http.NoBody)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Equal(t, `attachment; filename="access.log"`, resp.Header().Get("Content-Disposition"))
+}
+
+func TestDownload_ContentType(t *testing.T) {
+	router, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/access.log/download", http.NoBody)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Equal(t, "text/plain; charset=utf-8", resp.Header().Get("Content-Type"))
+}
+
+func TestDownload_TraversalRejected(t *testing.T) {
+	router, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Unknown (not in the raw log-directory listing) -> 404.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/unknown.log/download", http.NoBody)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusNotFound, resp.Code)
+
+	// Traversal-shaped via direct invocation (router would clean the path).
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "filename", Value: "/etc/passwd"}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/logs/x/download", http.NoBody)
+
+	svc := services.NewLogService(&config.Config{DatabasePath: filepath.Join(tmpDir, "data", "charon.db")})
+	h := NewLogsHandler(svc)
+	h.Download(c)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// Alias servability end-to-end: both names of the charon.log/cpmp.log symlink
+// pair must download successfully (allowlist is built pre-symlink-dedup).
+func TestDownload_SymlinkAliasesBothServable(t *testing.T) {
+	router, tmpDir := setupLogsTest(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	for _, name := range []string{"charon.log", "cpmp.log"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/"+name+"/download", http.NoBody)
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code, "alias %q must be servable", name)
+		require.Contains(t, resp.Body.String(), "app log line 1")
+	}
+}

--- a/backend/internal/models/log_entry.go
+++ b/backend/internal/models/log_entry.go
@@ -1,5 +1,10 @@
 package models
 
+import (
+	"errors"
+	"strings"
+)
+
 // CaddyAccessLog represents a structured log entry from Caddy's JSON access logs.
 type CaddyAccessLog struct {
 	Level   string  `json:"level"`
@@ -31,13 +36,56 @@ type CaddyAccessLog struct {
 	RespHeaders map[string][]string `json:"resp_headers"`
 }
 
-// LogFilter defines criteria for filtering logs.
+// LogFilter defines criteria for filtering, sorting, and paginating logs.
 type LogFilter struct {
 	Search string `form:"search"`
 	Host   string `form:"host"`
 	Status string `form:"status"` // e.g., "200", "4xx", "5xx"
 	Level  string `form:"level"`
-	Limit  int    `form:"limit"`
-	Offset int    `form:"offset"`
-	Sort   string `form:"sort"`
+	Limit  int    `form:"limit,default=50"`
+	Offset int    `form:"offset,default=0"`
+	Sort   string `form:"sort,default=desc"`  // direction: asc | desc
+	SortBy string `form:"sort_by,default=ts"` // field: see ValidSortFields
+}
+
+// ValidSortFields is the allowlist for LogFilter.SortBy.
+var ValidSortFields = map[string]bool{
+	"ts":     true,
+	"level":  true,
+	"method": true,
+	"uri":    true,
+	"status": true,
+}
+
+// ErrInvalidSortBy is returned by Validate when SortBy is not allowlisted.
+var ErrInvalidSortBy = errors.New("invalid sort_by: must be one of ts, level, method, uri, status")
+
+// Validate normalizes and validates the filter in place: it clamps Limit to
+// 1-500 (zero or negative values fall back to the default of 50), clamps
+// Offset to >= 0, lowercases Sort/SortBy, defaults invalid Sort directions to
+// "desc", and rejects SortBy values outside ValidSortFields.
+func (f *LogFilter) Validate() error {
+	if f.Limit <= 0 {
+		f.Limit = 50
+	}
+	if f.Limit > 500 {
+		f.Limit = 500
+	}
+	if f.Offset < 0 {
+		f.Offset = 0
+	}
+
+	f.Sort = strings.ToLower(f.Sort)
+	if f.Sort != "asc" && f.Sort != "desc" {
+		f.Sort = "desc"
+	}
+
+	f.SortBy = strings.ToLower(f.SortBy)
+	if f.SortBy == "" {
+		f.SortBy = "ts"
+	}
+	if !ValidSortFields[f.SortBy] {
+		return ErrInvalidSortBy
+	}
+	return nil
 }

--- a/backend/internal/models/log_entry_test.go
+++ b/backend/internal/models/log_entry_test.go
@@ -1,0 +1,103 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogFilterValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      LogFilter
+		want    LogFilter
+		wantErr string
+	}{
+		{
+			name: "defaults applied for zero values",
+			in:   LogFilter{},
+			want: LogFilter{Limit: 50, Offset: 0, Sort: "desc", SortBy: "ts"},
+		},
+		{
+			name: "valid values preserved",
+			in:   LogFilter{Limit: 100, Offset: 10, Sort: "asc", SortBy: "level"},
+			want: LogFilter{Limit: 100, Offset: 10, Sort: "asc", SortBy: "level"},
+		},
+		{
+			name: "limit zero treated as unset default 50",
+			in:   LogFilter{Limit: 0, SortBy: "ts"},
+			want: LogFilter{Limit: 50, Sort: "desc", SortBy: "ts"},
+		},
+		{
+			name: "negative limit treated as unset default 50",
+			in:   LogFilter{Limit: -5},
+			want: LogFilter{Limit: 50, Sort: "desc", SortBy: "ts"},
+		},
+		{
+			name: "limit clamped to 500",
+			in:   LogFilter{Limit: 9999},
+			want: LogFilter{Limit: 500, Sort: "desc", SortBy: "ts"},
+		},
+		{
+			name: "negative offset clamped to zero",
+			in:   LogFilter{Offset: -10},
+			want: LogFilter{Limit: 50, Offset: 0, Sort: "desc", SortBy: "ts"},
+		},
+		{
+			name: "sort direction lowercased",
+			in:   LogFilter{Sort: "ASC"},
+			want: LogFilter{Limit: 50, Sort: "asc", SortBy: "ts"},
+		},
+		{
+			name: "invalid sort direction falls back to desc",
+			in:   LogFilter{Sort: "sideways"},
+			want: LogFilter{Limit: 50, Sort: "desc", SortBy: "ts"},
+		},
+		{
+			name: "sort_by lowercased",
+			in:   LogFilter{SortBy: "STATUS"},
+			want: LogFilter{Limit: 50, Sort: "desc", SortBy: "status"},
+		},
+		{
+			name:    "invalid sort_by rejected",
+			in:      LogFilter{SortBy: "password"},
+			wantErr: "invalid sort_by: must be one of ts, level, method, uri, status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f := tt.in
+			err := f.Validate()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantErr, err.Error())
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.Limit, f.Limit)
+			assert.Equal(t, tt.want.Offset, f.Offset)
+			assert.Equal(t, tt.want.Sort, f.Sort)
+			assert.Equal(t, tt.want.SortBy, f.SortBy)
+		})
+	}
+}
+
+func TestLogFilterValidate_AllAllowlistedSortFields(t *testing.T) {
+	t.Parallel()
+
+	for field := range ValidSortFields {
+		f := LogFilter{SortBy: field}
+		require.NoError(t, f.Validate(), "sort_by %q must be accepted", field)
+		assert.Equal(t, field, f.SortBy)
+	}
+	// The allowlist is exactly the five documented fields.
+	assert.Len(t, ValidSortFields, 5)
+	for _, field := range []string{"ts", "level", "method", "uri", "status"} {
+		assert.True(t, ValidSortFields[field], "expected %q in allowlist", field)
+	}
+}

--- a/backend/internal/services/log_service.go
+++ b/backend/internal/services/log_service.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -80,8 +81,7 @@ func (s *LogService) ListLogs() ([]LogFile, error) {
 		}
 
 		for _, entry := range entries {
-			hasLogExtension := strings.HasSuffix(entry.Name(), ".log") || strings.Contains(entry.Name(), ".log.")
-			if entry.IsDir() || !hasLogExtension {
+			if entry.IsDir() || !isLogName(entry.Name()) {
 				continue
 			}
 
@@ -109,27 +109,125 @@ func (s *LogService) ListLogs() ([]LogFile, error) {
 	return logs, nil
 }
 
-// GetLogPath returns the absolute path to a log file if it exists and is valid
+// ErrInvalidFilename is the sentinel for traversal-shaped or
+// containment-violating filename rejections. Handlers map it to 400 via
+// errors.Is instead of matching error strings.
+var ErrInvalidFilename = errors.New("invalid filename: path traversal attempt detected")
+
+// isLogName reports whether a directory entry name follows the servable
+// log-file naming rules (".log" suffix or ".log." infix, e.g. rotations).
+func isLogName(name string) bool {
+	return strings.HasSuffix(name, ".log") || strings.Contains(name, ".log.")
+}
+
+// listServableNames returns the allowlist of servable filenames built from
+// RAW directory entries of every log dir. It deliberately does NOT reuse
+// ListLogs(): that method dedups symlink aliases by resolved path, which
+// would nondeterministically drop one name of a legitimate alias pair such
+// as charon.log/cpmp.log. Both alias names must remain servable.
+func (s *LogService) listServableNames() (map[string]bool, error) {
+	names := make(map[string]bool)
+	for _, dir := range s.logDirs() {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read log dir %q: %w", dir, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !isLogName(entry.Name()) {
+				continue
+			}
+			names[entry.Name()] = true
+		}
+	}
+	return names, nil
+}
+
+// GetLogPath validates a client-supplied filename and returns the
+// symlink-RESOLVED absolute path to the log file. Callers must open exactly
+// the returned path: because it contains no client-influenced symlink
+// component, a post-check symlink swap cannot redirect the open (TOCTOU).
+//
+// Defense-in-depth layers (spec §5.7):
+//  1. shape check (filepath.Base equality; empty/"."/".."/percent-encoded
+//     separators rejected) -> ErrInvalidFilename;
+//  2. allowlist against raw directory entries -> unknown names get
+//     os.ErrNotExist without opening any file;
+//  3. joined-path prefix containment in a cleaned log dir;
+//  4. both-sides EvalSymlinks containment: the resolved file must live inside
+//     a resolved log dir. This invariant is never relaxed under any
+//     configuration (R6).
 func (s *LogService) GetLogPath(filename string) (string, error) {
-	cleanName := filepath.Base(filename)
-	if filename != cleanName {
-		return "", fmt.Errorf("invalid filename: path traversal attempt detected")
+	invalid := func() (string, error) {
+		return "", fmt.Errorf("get log path %q: %w", filename, ErrInvalidFilename)
+	}
+	if filename == "" || filename == "." || filename == ".." {
+		return invalid()
+	}
+	if filename != filepath.Base(filename) {
+		return invalid()
+	}
+	// Reject literal percent-encoded path separators: they cannot appear in a
+	// legitimate log filename and only serve double-decode traversal attempts.
+	if lower := strings.ToLower(filename); strings.Contains(lower, "%2f") || strings.Contains(lower, "%5c") {
+		return invalid()
 	}
 
+	servable, err := s.listServableNames()
+	if err != nil {
+		return "", fmt.Errorf("list servable log names: %w", err)
+	}
+	if !servable[filename] {
+		return "", fmt.Errorf("log file %q not found: %w", filename, os.ErrNotExist)
+	}
+
+	var containmentErr error
 	for _, dir := range s.logDirs() {
 		baseDir := filepath.Clean(dir)
-		path := filepath.Join(baseDir, cleanName)
+		path := filepath.Join(baseDir, filename)
 		if !strings.HasPrefix(path, baseDir+string(os.PathSeparator)) {
 			continue
 		}
 
-		// Verify file exists
-		if _, err := os.Stat(path); err == nil {
-			return path, nil
+		resolved, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			continue // missing in this dir, or dangling symlink
 		}
+		info, err := os.Stat(resolved)
+		if err != nil || !info.Mode().IsRegular() {
+			continue // never serve directories or special files
+		}
+		if s.resolvedInLogDirs(resolved) {
+			return resolved, nil
+		}
+		// Found but resolves outside every resolved log dir: refuse (R6).
+		containmentErr = fmt.Errorf("log file %q resolves outside the log directories: %w", filename, ErrInvalidFilename)
 	}
 
-	return "", os.ErrNotExist
+	if containmentErr != nil {
+		return "", containmentErr
+	}
+	return "", fmt.Errorf("log file %q not found: %w", filename, os.ErrNotExist)
+}
+
+// resolvedInLogDirs reports whether the already-resolved file path lies
+// inside the EvalSymlinks-resolved form of one of the log dirs. Resolving
+// BOTH sides also covers layouts where a log dir itself (or an ancestor)
+// is a symlink.
+func (s *LogService) resolvedInLogDirs(resolved string) bool {
+	parent := filepath.Dir(resolved)
+	for _, dir := range s.logDirs() {
+		resolvedDir, err := filepath.EvalSymlinks(filepath.Clean(dir))
+		if err != nil {
+			continue
+		}
+		if parent == resolvedDir || strings.HasPrefix(parent, resolvedDir+string(os.PathSeparator)) {
+			return true
+		}
+	}
+	return false
 }
 
 // QueryLogs parses, filters, sorts, and paginates logs from a specific file.

--- a/backend/internal/services/log_service.go
+++ b/backend/internal/services/log_service.go
@@ -2,19 +2,26 @@ package services
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
-
+	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Wikid82/charon/backend/internal/config"
 	"github.com/Wikid82/charon/backend/internal/logger"
 	"github.com/Wikid82/charon/backend/internal/models"
 )
+
+// maxLogLineBytes caps a single log line at 1MB. Longer lines are counted as
+// skipped and discarded chunk-by-chunk without ever being accumulated in full.
+const maxLogLineBytes = 1 << 20
 
 type LogService struct {
 	LogDir      string
@@ -125,17 +132,21 @@ func (s *LogService) GetLogPath(filename string) (string, error) {
 	return "", os.ErrNotExist
 }
 
-// QueryLogs parses and filters logs from a specific file
-func (s *LogService) QueryLogs(filename string, filter models.LogFilter) ([]models.CaddyAccessLog, int64, error) {
+// QueryLogs parses, filters, sorts, and paginates logs from a specific file.
+// It returns the requested page, the total number of filtered matches, and
+// the number of lines skipped as corrupted or oversized (R4).
+func (s *LogService) QueryLogs(filename string, filter models.LogFilter) ([]models.CaddyAccessLog, int64, int64, error) {
 	path, err := s.GetLogPath(filename)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, 0, err
 	}
 
-	// #nosec G304 -- path is validated by GetLogPath to be within logDir
+	// #nosec G304 -- path is the symlink-resolved location returned by
+	// GetLogPath, which enforces filepath.Base equality, a raw directory-entry
+	// allowlist, and EvalSymlinks containment inside the configured log dirs.
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, 0, fmt.Errorf("open log file: %w", err)
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
@@ -143,72 +154,171 @@ func (s *LogService) QueryLogs(filename string, filter models.LogFilter) ([]mode
 		}
 	}()
 
-	var logs []models.CaddyAccessLog
-	var totalMatches int64
+	// Read line by line with a hard per-line cap. bufio.Scanner is not used
+	// because a single oversized line would abort the whole query; and
+	// ReadBytes('\n') is not used because it buffers the entire line before
+	// returning. ReadSlice hands back the reader's internal buffer chunk by
+	// chunk, so an over-cap line is counted and discarded without ever being
+	// accumulated beyond the cap.
+	// The full filtered match set is held in memory to sort and count; this is
+	// bounded by the rotation cap (~10MB) and acceptable for rotated logs.
+	var (
+		logs         []models.CaddyAccessLog
+		skippedLines int64
+		reader       = bufio.NewReader(file)
+		scratch      = make([]byte, 0, 64*1024)
+		overCap      bool
+	)
 
-	// Read file line by line
-	// TODO: For large files, reading from end or indexing would be better
-	// Current implementation reads all lines, filters, then paginates
-	// This is acceptable for rotated logs (max 10MB)
-	scanner := bufio.NewScanner(file)
-
-	// We'll store all matching logs first, then slice for pagination
-	// This is memory intensive for very large matches but ensures correct sorting/filtering
-	// Since we want latest first, we'll prepend or reverse later.
-	// Actually, appending and then reversing is better.
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
+	processLine := func(line []byte) {
+		if len(line) == 0 {
+			return
 		}
-
-		var entry models.CaddyAccessLog
-		if err := json.Unmarshal([]byte(line), &entry); err != nil {
-			// Handle non-JSON logs (like cpmp.log, legacy name for Charon)
-			// Try to parse standard Go log format: "2006/01/02 15:04:05 msg"
-			parts := strings.SplitN(line, " ", 3)
-			entry.Msg = line
-			entry.Level = "INFO" // Default level for plain logs
-			if len(parts) >= 3 {
-				// Try parsing date/time; if parsing fails, keep the original line as the Msg
-				if ts, perr := time.Parse("2006/01/02 15:04:05", parts[0]+" "+parts[1]); perr == nil {
-					entry.Ts = float64(ts.Unix())
-					entry.Msg = parts[2]
-				}
-			}
+		entry, ok := parseLogLine(line)
+		if !ok {
+			skippedLines++
+			return
 		}
-
 		if s.matchesFilter(entry, filter) {
 			logs = append(logs, entry)
 		}
 	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, 0, err
-	}
+	for {
+		chunk, rerr := reader.ReadSlice('\n')
+		if len(chunk) > 0 && !overCap {
+			// +1 tolerates the trailing newline still present in the chunk.
+			if len(scratch)+len(chunk) > maxLogLineBytes+1 {
+				overCap = true
+				scratch = scratch[:0] // discard; do not accumulate past the cap
+			} else {
+				scratch = append(scratch, chunk...)
+			}
+		}
+		if rerr == bufio.ErrBufferFull {
+			continue // same line keeps going; loop for the next chunk
+		}
+		if rerr != nil && rerr != io.EOF {
+			return nil, 0, 0, fmt.Errorf("read log file: %w", rerr)
+		}
 
-	// Reverse logs to show newest first (default) unless sort is asc
-	if filter.Sort != "asc" {
-		for i, j := 0, len(logs)-1; i < j; i, j = i+1, j-1 {
-			logs[i], logs[j] = logs[j], logs[i]
+		// End of line (newline consumed) or EOF reached.
+		line := bytes.TrimRight(scratch, "\r\n")
+		if overCap || len(line) > maxLogLineBytes {
+			skippedLines++
+		} else {
+			processLine(line)
+		}
+		scratch = scratch[:0]
+		overCap = false
+
+		if rerr == io.EOF {
+			break
 		}
 	}
 
-	totalMatches = int64(len(logs))
+	sortEntries(logs, filter.SortBy, filter.Sort)
+
+	totalMatches := int64(len(logs))
 
 	// Apply pagination
 	start := filter.Offset
 	end := start + filter.Limit
 
 	if start >= len(logs) {
-		return []models.CaddyAccessLog{}, totalMatches, nil
+		return []models.CaddyAccessLog{}, totalMatches, skippedLines, nil
 	}
 	if end > len(logs) {
 		end = len(logs)
 	}
 
-	return logs[start:end], totalMatches, nil
+	return logs[start:end], totalMatches, skippedLines, nil
+}
+
+// parseLogLine parses a single log line. It returns ok=false only for
+// corrupted lines per R4: the line failed JSON parsing AND is either invalid
+// UTF-8 or contains a NUL byte. Any other non-JSON line takes the plain-text
+// fallback (legitimate charon.log lines).
+func parseLogLine(line []byte) (models.CaddyAccessLog, bool) {
+	var entry models.CaddyAccessLog
+	if err := json.Unmarshal(line, &entry); err == nil {
+		return entry, true
+	}
+	if !utf8.Valid(line) || bytes.IndexByte(line, 0) >= 0 {
+		return entry, false
+	}
+
+	// Handle non-JSON logs (like cpmp.log, legacy name for Charon).
+	// Try to parse standard Go log format: "2006/01/02 15:04:05 msg".
+	text := string(line)
+	parts := strings.SplitN(text, " ", 3)
+	entry.Msg = text
+	entry.Level = "INFO" // Default level for plain logs
+	if len(parts) >= 3 {
+		// Try parsing date/time; if parsing fails, keep the original line as the Msg
+		if ts, perr := time.Parse("2006/01/02 15:04:05", parts[0]+" "+parts[1]); perr == nil {
+			entry.Ts = float64(ts.Unix())
+			entry.Msg = parts[2]
+		}
+	}
+	return entry, true
+}
+
+// levelRank maps a log level to its severity rank for sorting (R3):
+// debug < info < warn < error; unknown levels rank lowest.
+func levelRank(level string) int {
+	switch strings.ToLower(level) {
+	case "debug":
+		return 0
+	case "info":
+		return 1
+	case "warn":
+		return 2
+	case "error":
+		return 3
+	default:
+		return -1
+	}
+}
+
+// sortEntries stably sorts logs by the given field and direction (R1).
+// Entries with equal keys fall through to Ts descending so pages stay
+// deterministic. An empty sortBy/dir falls back to ts/desc.
+func sortEntries(logs []models.CaddyAccessLog, sortBy, dir string) {
+	asc := dir == "asc"
+
+	compare := func(a, b models.CaddyAccessLog) int {
+		switch sortBy {
+		case "level":
+			return levelRank(a.Level) - levelRank(b.Level)
+		case "method":
+			return strings.Compare(strings.ToLower(a.Request.Method), strings.ToLower(b.Request.Method))
+		case "uri":
+			return strings.Compare(strings.ToLower(a.Request.URI), strings.ToLower(b.Request.URI))
+		case "status":
+			return a.Status - b.Status
+		default: // "ts"
+			switch {
+			case a.Ts < b.Ts:
+				return -1
+			case a.Ts > b.Ts:
+				return 1
+			default:
+				return 0
+			}
+		}
+	}
+
+	sort.SliceStable(logs, func(i, j int) bool {
+		c := compare(logs[i], logs[j])
+		if c == 0 {
+			return logs[i].Ts > logs[j].Ts // ts-descending tiebreaker
+		}
+		if asc {
+			return c < 0
+		}
+		return c > 0
+	})
 }
 
 func (s *LogService) matchesFilter(entry models.CaddyAccessLog, filter models.LogFilter) bool {

--- a/backend/internal/services/log_service_security_test.go
+++ b/backend/internal/services/log_service_security_test.go
@@ -1,0 +1,206 @@
+package services
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Wikid82/charon/backend/internal/config"
+	"github.com/Wikid82/charon/backend/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// securityFixtureService creates a log dir containing real.log and returns
+// the service plus the log dir path.
+func securityFixtureService(t *testing.T) (*LogService, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	dataDir := filepath.Join(tmpDir, "data")
+	logsDir := filepath.Join(dataDir, "logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "real.log"), []byte("line\n"), 0o600)) // #nosec G306 -- test fixture
+
+	service := NewLogService(&config.Config{DatabasePath: filepath.Join(dataDir, "charon.db")})
+	return service, logsDir
+}
+
+func TestGetLogPath_Traversal(t *testing.T) {
+	service, _ := securityFixtureService(t)
+
+	traversalShaped := []string{
+		"../secret",
+		"..%2Fsecret", // literal percent-encoded separator
+		"/etc/passwd",
+		"a/../b.log",
+		".",
+		"..",
+		"",
+	}
+	for _, name := range traversalShaped {
+		t.Run("shape_"+name, func(t *testing.T) {
+			_, err := service.GetLogPath(name)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrInvalidFilename),
+				"expected ErrInvalidFilename for %q, got: %v", name, err)
+		})
+	}
+
+	// Name absent from the raw directory listing -> os.ErrNotExist without
+	// opening any file.
+	_, err := service.GetLogPath("unknown.log")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+
+	// A well-shaped name that is not a log file (extension rules) is not
+	// servable either.
+	_, err = service.GetLogPath("notes.txt")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+}
+
+func TestGetLogPath_SymlinkEscapeRejected(t *testing.T) {
+	service, logsDir := securityFixtureService(t)
+
+	// Plant a symlink inside the log dir pointing OUTSIDE all log dirs.
+	outsideDir := t.TempDir()
+	secret := filepath.Join(outsideDir, "secret")
+	require.NoError(t, os.WriteFile(secret, []byte("top secret"), 0o600)) // #nosec G306 -- test fixture
+	require.NoError(t, os.Symlink(secret, filepath.Join(logsDir, "evil.log")))
+
+	_, err := service.GetLogPath("evil.log")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidFilename),
+		"symlink escape must be refused, got: %v", err)
+}
+
+func TestGetLogPath_SymlinkedLogDirStillAllowed(t *testing.T) {
+	// A log dir that is ITSELF a symlink must not break containment for
+	// legitimately contained files (both-sides resolution).
+	tmpDir := t.TempDir()
+	realDir := filepath.Join(tmpDir, "real-logs")
+	require.NoError(t, os.MkdirAll(realDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(realDir, "contained.log"), []byte("line\n"), 0o600)) // #nosec G306 -- test fixture
+
+	linkDir := filepath.Join(tmpDir, "link-logs")
+	require.NoError(t, os.Symlink(realDir, linkDir))
+
+	service := &LogService{LogDir: linkDir}
+	path, err := service.GetLogPath("contained.log")
+	require.NoError(t, err)
+
+	resolvedReal, err := filepath.EvalSymlinks(filepath.Join(realDir, "contained.log"))
+	require.NoError(t, err)
+	assert.Equal(t, resolvedReal, path)
+}
+
+func TestGetLogPath_SymlinkAliasesBothServable(t *testing.T) {
+	// Guards the ListLogs-dedup finding: BOTH names of a legitimate same-dir
+	// alias pair (charon.log / cpmp.log) must stay servable, because the
+	// allowlist is built from RAW directory entries, not ListLogs output.
+	service, logsDir := securityFixtureService(t)
+	require.NoError(t, os.Symlink(filepath.Join(logsDir, "real.log"), filepath.Join(logsDir, "alias.log")))
+
+	realResolved, err := filepath.EvalSymlinks(filepath.Join(logsDir, "real.log"))
+	require.NoError(t, err)
+
+	pathReal, err := service.GetLogPath("real.log")
+	require.NoError(t, err)
+	assert.Equal(t, realResolved, pathReal)
+
+	pathAlias, err := service.GetLogPath("alias.log")
+	require.NoError(t, err)
+	assert.Equal(t, realResolved, pathAlias)
+}
+
+func TestGetLogPath_ReturnsResolvedPath(t *testing.T) {
+	// TOCTOU guard: for a symlinked name the returned path is the
+	// EvalSymlinks target (callers open exactly this path).
+	service, logsDir := securityFixtureService(t)
+	require.NoError(t, os.Symlink(filepath.Join(logsDir, "real.log"), filepath.Join(logsDir, "alias.log")))
+
+	path, err := service.GetLogPath("alias.log")
+	require.NoError(t, err)
+
+	target, err := filepath.EvalSymlinks(filepath.Join(logsDir, "real.log"))
+	require.NoError(t, err)
+	assert.Equal(t, target, path, "returned path must be the resolved target, not the symlink")
+	assert.NotEqual(t, filepath.Join(logsDir, "alias.log"), path)
+}
+
+func TestGetLogPath_ListServableNamesError(t *testing.T) {
+	// Log dir is a file, so os.ReadDir fails with a non-NotExist error which
+	// must be wrapped and surfaced.
+	tmpDir := t.TempDir()
+	notDir := filepath.Join(tmpDir, "not-a-dir")
+	require.NoError(t, os.WriteFile(notDir, []byte("x"), 0o600)) // #nosec G306 -- test fixture
+
+	service := &LogService{LogDir: notDir}
+	_, err := service.GetLogPath("real.log")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list servable log names")
+}
+
+func TestGetLogPath_DanglingSymlinkIsNotFound(t *testing.T) {
+	service, logsDir := securityFixtureService(t)
+	require.NoError(t, os.Symlink(filepath.Join(logsDir, "gone.log"), filepath.Join(logsDir, "dangling.log")))
+
+	_, err := service.GetLogPath("dangling.log")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+}
+
+func TestGetLogPath_SymlinkToDirectoryRejected(t *testing.T) {
+	// A symlink whose target is a directory must never be served.
+	service, logsDir := securityFixtureService(t)
+	targetDir := t.TempDir()
+	require.NoError(t, os.Symlink(targetDir, filepath.Join(logsDir, "dir.log")))
+
+	_, err := service.GetLogPath("dir.log")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, os.ErrNotExist), "non-regular resolved target must not be servable, got: %v", err)
+}
+
+func TestGetLogPath_SkipsUnresolvableLogDir(t *testing.T) {
+	// One configured log dir does not exist; containment must still succeed
+	// against the resolvable dir (resolvedInLogDirs skips the bad one).
+	tmpDir := t.TempDir()
+	caddyDir := filepath.Join(tmpDir, "caddy-logs")
+	require.NoError(t, os.MkdirAll(caddyDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(caddyDir, "caddy.log"), []byte("line\n"), 0o600)) // #nosec G306 -- test fixture
+
+	service := &LogService{
+		LogDir:      filepath.Join(tmpDir, "missing-logs"), // does not exist
+		CaddyLogDir: caddyDir,
+	}
+
+	path, err := service.GetLogPath("caddy.log")
+	require.NoError(t, err)
+	resolved, err := filepath.EvalSymlinks(filepath.Join(caddyDir, "caddy.log"))
+	require.NoError(t, err)
+	assert.Equal(t, resolved, path)
+}
+
+func TestQueryLogs_InvalidFilenamePropagatesSentinel(t *testing.T) {
+	service, _ := securityFixtureService(t)
+	_, _, _, err := service.QueryLogs("../real.log", models.LogFilter{Limit: 10})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidFilename))
+}
+
+func TestListServableNames_RawEntriesPreDedup(t *testing.T) {
+	service, logsDir := securityFixtureService(t)
+	require.NoError(t, os.Symlink(filepath.Join(logsDir, "real.log"), filepath.Join(logsDir, "alias.log")))
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "rotated.log.1"), []byte("x\n"), 0o600)) // #nosec G306 -- test fixture
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "notes.txt"), []byte("x\n"), 0o600))     // #nosec G306 -- test fixture
+	require.NoError(t, os.MkdirAll(filepath.Join(logsDir, "sub.log"), 0o750))                       // directory with log-ish name
+
+	names, err := service.listServableNames()
+	require.NoError(t, err)
+	assert.True(t, names["real.log"])
+	assert.True(t, names["alias.log"], "both symlink alias names must be servable (pre-dedup)")
+	assert.True(t, names["rotated.log.1"])
+	assert.False(t, names["notes.txt"])
+	assert.False(t, names["sub.log"], "directories are never servable")
+}

--- a/backend/internal/services/log_service_sort_test.go
+++ b/backend/internal/services/log_service_sort_test.go
@@ -1,0 +1,177 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Wikid82/charon/backend/internal/config"
+	"github.com/Wikid82/charon/backend/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sortFixtureService writes six mixed entries (file order = ts ascending) and
+// returns a service whose log dir contains "sort.log". Used by the sort_by tests.
+//
+//	msg  ts   level    method  uri  status
+//	e1   100  info     GET     /b   200
+//	e2   200  error    post    /a   500
+//	e3   300  debug    DELETE  /C   404
+//	e4   400  warn     PUT     /d   200
+//	e5   500  UNKNOWN  PATCH   /e   301
+//	e6   600  info     get     /f   502
+func sortFixtureService(t *testing.T) *LogService {
+	t.Helper()
+	tmpDir := t.TempDir()
+	dataDir := filepath.Join(tmpDir, "data")
+	logsDir := filepath.Join(dataDir, "logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0o750))
+
+	lines := []string{
+		`{"level":"info","ts":100,"msg":"e1","request":{"method":"GET","uri":"/b"},"status":200}`,
+		`{"level":"error","ts":200,"msg":"e2","request":{"method":"post","uri":"/a"},"status":500}`,
+		`{"level":"debug","ts":300,"msg":"e3","request":{"method":"DELETE","uri":"/C"},"status":404}`,
+		`{"level":"warn","ts":400,"msg":"e4","request":{"method":"PUT","uri":"/d"},"status":200}`,
+		`{"level":"UNKNOWN","ts":500,"msg":"e5","request":{"method":"PATCH","uri":"/e"},"status":301}`,
+		`{"level":"info","ts":600,"msg":"e6","request":{"method":"get","uri":"/f"},"status":502}`,
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "sort.log"), []byte(content), 0o600)) // #nosec G306 -- test fixture
+
+	return NewLogService(&config.Config{DatabasePath: filepath.Join(dataDir, "charon.db")})
+}
+
+func msgs(entries []models.CaddyAccessLog) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Msg
+	}
+	return out
+}
+
+func TestQueryLogs_SortBy(t *testing.T) {
+	service := sortFixtureService(t)
+
+	tests := []struct {
+		sortBy string
+		dir    string
+		want   []string
+	}{
+		{"ts", "asc", []string{"e1", "e2", "e3", "e4", "e5", "e6"}},
+		{"ts", "desc", []string{"e6", "e5", "e4", "e3", "e2", "e1"}},
+		// level rank: unknown(-1) < debug < info < warn < error; equal info pair tiebreaks ts desc (e6 before e1)
+		{"level", "asc", []string{"e5", "e3", "e6", "e1", "e4", "e2"}},
+		{"level", "desc", []string{"e2", "e4", "e6", "e1", "e3", "e5"}},
+		// method case-insensitive; GET==get tiebreaks ts desc (e6 before e1)
+		{"method", "asc", []string{"e3", "e6", "e1", "e5", "e2", "e4"}},
+		{"method", "desc", []string{"e4", "e2", "e5", "e6", "e1", "e3"}},
+		// uri case-insensitive (/C sorts between /b and /d)
+		{"uri", "asc", []string{"e2", "e1", "e3", "e4", "e5", "e6"}},
+		{"uri", "desc", []string{"e6", "e5", "e4", "e3", "e1", "e2"}},
+		// status numeric; equal 200 pair tiebreaks ts desc (e4 before e1) in BOTH directions (deterministic pages)
+		{"status", "asc", []string{"e4", "e1", "e5", "e3", "e2", "e6"}},
+		{"status", "desc", []string{"e6", "e2", "e3", "e5", "e4", "e1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sortBy+"_"+tt.dir, func(t *testing.T) {
+			results, total, skipped, err := service.QueryLogs("sort.log", models.LogFilter{
+				Limit: 10, Sort: tt.dir, SortBy: tt.sortBy,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, int64(6), total)
+			assert.Equal(t, int64(0), skipped)
+			assert.Equal(t, tt.want, msgs(results))
+		})
+	}
+}
+
+func TestQueryLogs_LevelRank(t *testing.T) {
+	assert.Equal(t, 0, levelRank("debug"))
+	assert.Equal(t, 1, levelRank("info"))
+	assert.Equal(t, 2, levelRank("warn"))
+	assert.Equal(t, 3, levelRank("error"))
+	assert.Equal(t, -1, levelRank("mystery"))
+	assert.Equal(t, -1, levelRank(""))
+	// case-insensitive
+	assert.Equal(t, 3, levelRank("ERROR"))
+	assert.Equal(t, 1, levelRank("Info"))
+}
+
+func TestQueryLogs_PaginationEdges(t *testing.T) {
+	service := sortFixtureService(t)
+
+	// Offset beyond total -> empty page, correct total.
+	results, total, _, err := service.QueryLogs("sort.log", models.LogFilter{Limit: 10, Offset: 100})
+	require.NoError(t, err)
+	assert.Equal(t, int64(6), total)
+	assert.Empty(t, results)
+
+	// Partial last page.
+	results, total, _, err = service.QueryLogs("sort.log", models.LogFilter{Limit: 4, Offset: 4})
+	require.NoError(t, err)
+	assert.Equal(t, int64(6), total)
+	assert.Len(t, results, 2)
+
+	// Limit clamping happens ONLY in Validate (not duplicated in QueryLogs).
+	zero := models.LogFilter{Limit: 0}
+	require.NoError(t, zero.Validate())
+	assert.Equal(t, 50, zero.Limit)
+	results, _, _, err = service.QueryLogs("sort.log", zero)
+	require.NoError(t, err)
+	assert.Len(t, results, 6)
+
+	huge := models.LogFilter{Limit: 9999}
+	require.NoError(t, huge.Validate())
+	assert.Equal(t, 500, huge.Limit)
+}
+
+func TestQueryLogs_CorruptedLines(t *testing.T) {
+	tmpDir := t.TempDir()
+	dataDir := filepath.Join(tmpDir, "data")
+	logsDir := filepath.Join(dataDir, "logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0o750))
+
+	oversized := strings.Repeat("a", (1<<20)+100) // > 1MB single line -> skipped, loop continues
+
+	var content strings.Builder
+	content.WriteString(`{"level":"info","ts":1,"msg":"json before"}` + "\n")
+	content.WriteString("plain text fallback line\n")                 // valid UTF-8, no NUL -> fallback, NOT skipped
+	content.WriteString("corrupt\x00with nul\n")                      // JSON-fail + NUL byte -> skipped
+	content.WriteString("bad utf8 \xff\xfe\xfd here\n")               // JSON-fail + invalid UTF-8 -> skipped
+	content.WriteString(oversized + "\n")                             // over per-line cap -> skipped, loop continues
+	content.WriteString(`{"level":"info","ts":2,"msg":"json after"}` + "\n")
+
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "mixed.log"), []byte(content.String()), 0o600)) // #nosec G306 -- test fixture
+
+	service := NewLogService(&config.Config{DatabasePath: filepath.Join(dataDir, "charon.db")})
+
+	results, total, skipped, err := service.QueryLogs("mixed.log", models.LogFilter{Limit: 50, Sort: "asc"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), total, "two JSON lines + one plain-text fallback line")
+	assert.Equal(t, int64(3), skipped, "NUL line + invalid UTF-8 line + oversized line")
+
+	got := msgs(results)
+	assert.Contains(t, got, "json before")
+	assert.Contains(t, got, "json after")
+	assert.Contains(t, got, "plain text fallback line")
+}
+
+func TestQueryLogs_ValidJSONWithEscapedNulIsKept(t *testing.T) {
+	// A JSON line that PARSES is never treated as corruption, whatever it encodes.
+	tmpDir := t.TempDir()
+	dataDir := filepath.Join(tmpDir, "data")
+	logsDir := filepath.Join(dataDir, "logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0o750))
+	line := "{\"level\":\"info\",\"ts\":1,\"msg\":\"escaped \\u0000 nul\"}"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "esc.log"), []byte(line+"\n"), 0o600)) // #nosec G306 -- test fixture
+
+	service := NewLogService(&config.Config{DatabasePath: filepath.Join(dataDir, "charon.db")})
+	results, total, skipped, err := service.QueryLogs("esc.log", models.LogFilter{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, int64(0), skipped)
+	require.Len(t, results, 1)
+}

--- a/backend/internal/services/log_service_sort_test.go
+++ b/backend/internal/services/log_service_sort_test.go
@@ -88,6 +88,25 @@ func TestQueryLogs_SortBy(t *testing.T) {
 	}
 }
 
+func TestQueryLogs_EqualTsIsStable(t *testing.T) {
+	// Entries with identical timestamps keep file order (sort.SliceStable):
+	// the ts comparator returns equal and the ts-desc tiebreaker is also equal.
+	tmpDir := t.TempDir()
+	dataDir := filepath.Join(tmpDir, "data")
+	logsDir := filepath.Join(dataDir, "logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0o750))
+	content := `{"level":"info","ts":100,"msg":"first"}` + "\n" +
+		`{"level":"info","ts":100,"msg":"second"}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "equal.log"), []byte(content), 0o600)) // #nosec G306 -- test fixture
+
+	service := NewLogService(&config.Config{DatabasePath: filepath.Join(dataDir, "charon.db")})
+	for _, dir := range []string{"asc", "desc"} {
+		results, _, _, err := service.QueryLogs("equal.log", models.LogFilter{Limit: 10, Sort: dir, SortBy: "ts"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"first", "second"}, msgs(results), "direction %s must be stable", dir)
+	}
+}
+
 func TestQueryLogs_LevelRank(t *testing.T) {
 	assert.Equal(t, 0, levelRank("debug"))
 	assert.Equal(t, 1, levelRank("info"))
@@ -138,10 +157,10 @@ func TestQueryLogs_CorruptedLines(t *testing.T) {
 
 	var content strings.Builder
 	content.WriteString(`{"level":"info","ts":1,"msg":"json before"}` + "\n")
-	content.WriteString("plain text fallback line\n")                 // valid UTF-8, no NUL -> fallback, NOT skipped
-	content.WriteString("corrupt\x00with nul\n")                      // JSON-fail + NUL byte -> skipped
-	content.WriteString("bad utf8 \xff\xfe\xfd here\n")               // JSON-fail + invalid UTF-8 -> skipped
-	content.WriteString(oversized + "\n")                             // over per-line cap -> skipped, loop continues
+	content.WriteString("plain text fallback line\n")   // valid UTF-8, no NUL -> fallback, NOT skipped
+	content.WriteString("corrupt\x00with nul\n")        // JSON-fail + NUL byte -> skipped
+	content.WriteString("bad utf8 \xff\xfe\xfd here\n") // JSON-fail + invalid UTF-8 -> skipped
+	content.WriteString(oversized + "\n")               // over per-line cap -> skipped, loop continues
 	content.WriteString(`{"level":"info","ts":2,"msg":"json after"}` + "\n")
 
 	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "mixed.log"), []byte(content.String()), 0o600)) // #nosec G306 -- test fixture

--- a/backend/internal/services/log_service_test.go
+++ b/backend/internal/services/log_service_test.go
@@ -65,7 +65,7 @@ func TestLogService(t *testing.T) {
 	assert.Equal(t, "access.log", logs[0].Name)
 
 	// Test QueryLogs - All
-	results, total, err := service.QueryLogs("access.log", models.LogFilter{Limit: 10})
+	results, total, _, err := service.QueryLogs("access.log", models.LogFilter{Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), total)
 	assert.Len(t, results, 2)
@@ -74,21 +74,21 @@ func TestLogService(t *testing.T) {
 	assert.Equal(t, 200, results[1].Status)
 
 	// Test QueryLogs - Filter Status
-	results, total, err = service.QueryLogs("access.log", models.LogFilter{Status: "5xx", Limit: 10})
+	results, total, _, err = service.QueryLogs("access.log", models.LogFilter{Status: "5xx", Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), total)
 	assert.Len(t, results, 1)
 	assert.Equal(t, 500, results[0].Status)
 
 	// Test QueryLogs - Filter Host
-	results, total, err = service.QueryLogs("access.log", models.LogFilter{Host: "api.example.com", Limit: 10})
+	results, total, _, err = service.QueryLogs("access.log", models.LogFilter{Host: "api.example.com", Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), total)
 	assert.Len(t, results, 1)
 	assert.Equal(t, "api.example.com", results[0].Request.Host)
 
 	// Test QueryLogs - Search
-	results, total, err = service.QueryLogs("access.log", models.LogFilter{Search: "submit", Limit: 10})
+	results, total, _, err = service.QueryLogs("access.log", models.LogFilter{Search: "submit", Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), total)
 	assert.Len(t, results, 1)
@@ -123,45 +123,46 @@ func TestLogService(t *testing.T) {
 	err = os.WriteFile(filepath.Join(logsDir, "app.log"), []byte(plainContent), 0o600) // #nosec G306 -- test fixture
 	require.NoError(t, err)
 
-	results, total, err = service.QueryLogs("app.log", models.LogFilter{Limit: 10})
+	results, total, _, err = service.QueryLogs("app.log", models.LogFilter{Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), total)
-	// Reverse order check
-	assert.Equal(t, "Just a plain line", results[0].Msg)
-	assert.Equal(t, "Application started", results[1].Msg)
-	assert.Equal(t, "INFO", results[1].Level)
+	// Default sort is ts desc: the line with a parsed timestamp sorts before
+	// the plain line whose timestamp could not be parsed (Ts=0 ranks last).
+	assert.Equal(t, "Application started", results[0].Msg)
+	assert.Equal(t, "Just a plain line", results[1].Msg)
+	assert.Equal(t, "INFO", results[0].Level)
 
 	// Test QueryLogs - Pagination
 	// We have 2 logs in access.log
-	results, _, err = service.QueryLogs("access.log", models.LogFilter{Limit: 1, Offset: 0})
+	results, _, _, err = service.QueryLogs("access.log", models.LogFilter{Limit: 1, Offset: 0})
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, 500, results[0].Status) // Newest first
 
-	results, _, err = service.QueryLogs("access.log", models.LogFilter{Limit: 1, Offset: 1})
+	results, _, _, err = service.QueryLogs("access.log", models.LogFilter{Limit: 1, Offset: 1})
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, 200, results[0].Status) // Second newest
 
-	results, _, err = service.QueryLogs("access.log", models.LogFilter{Limit: 10, Offset: 5})
+	results, _, _, err = service.QueryLogs("access.log", models.LogFilter{Limit: 10, Offset: 5})
 	require.NoError(t, err)
 	assert.Empty(t, results)
 
 	// Test QueryLogs - Exact Status Match
-	results, total, err = service.QueryLogs("access.log", models.LogFilter{Status: "200", Limit: 10})
+	results, total, _, err = service.QueryLogs("access.log", models.LogFilter{Status: "200", Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), total)
 	assert.Equal(t, 200, results[0].Status)
 
 	// Test QueryLogs - Search Fields
 	// Search Method
-	results, total, err = service.QueryLogs("access.log", models.LogFilter{Search: "POST", Limit: 10})
+	results, total, _, err = service.QueryLogs("access.log", models.LogFilter{Search: "POST", Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), total)
 	assert.Equal(t, "POST", results[0].Request.Method)
 
 	// Search RemoteIP
-	results, total, err = service.QueryLogs("access.log", models.LogFilter{Search: "5.6.7.8", Limit: 10})
+	results, total, _, err = service.QueryLogs("access.log", models.LogFilter{Search: "5.6.7.8", Limit: 10})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), total)
 	assert.Equal(t, "5.6.7.8", results[0].Request.RemoteIP)

--- a/backend/internal/services/security_service.go
+++ b/backend/internal/services/security_service.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,12 +25,13 @@ var (
 )
 
 type SecurityService struct {
-	db        *gorm.DB
-	auditChan chan *models.SecurityAudit
-	done      chan struct{}  // Channel to signal goroutine to stop
-	wg        sync.WaitGroup // WaitGroup to track goroutine completion
-	closed    bool           // Flag to prevent double-close
-	mu        sync.Mutex     // Mutex to protect closed flag
+	db            *gorm.DB
+	auditChan     chan *models.SecurityAudit
+	done          chan struct{}  // Channel to signal goroutine to stop
+	wg            sync.WaitGroup // WaitGroup to track goroutine completion
+	closed        bool           // Flag to prevent double-close
+	mu            sync.Mutex     // Mutex to protect closed flag
+	pendingAudits atomic.Int64   // Audits accepted by LogAudit but not yet persisted
 }
 
 // NewSecurityService returns a SecurityService using the provided DB
@@ -60,17 +62,14 @@ func (s *SecurityService) Close() {
 	s.wg.Wait()        // Wait for the goroutine to finish
 }
 
-// Flush processes all pending audit logs synchronously (useful for testing)
+// Flush blocks until every audit accepted by LogAudit has been persisted
+// (useful for testing). A generous deadline prevents hanging on a wedged
+// database; channel length is not a reliable signal because an audit the
+// worker has dequeued but not yet written is in neither the channel nor the DB.
 func (s *SecurityService) Flush() {
-	// Wait for all pending audits to be processed
-	// In practice, we wait for the channel to be empty and then a bit more
-	// to ensure the database write completes
-	for i := 0; i < 20; i++ { // Max 200ms wait
-		if len(s.auditChan) == 0 {
-			time.Sleep(10 * time.Millisecond) // Extra wait for DB write
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+	deadline := time.Now().Add(5 * time.Second)
+	for s.pendingAudits.Load() > 0 && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
 	}
 }
 
@@ -248,11 +247,16 @@ func (s *SecurityService) LogAudit(a *models.SecurityAudit) error {
 		a.CreatedAt = time.Now()
 	}
 
+	// Count before enqueueing so Flush never observes a gap between an
+	// audit being accepted and the worker picking it up.
+	s.pendingAudits.Add(1)
+
 	// Non-blocking send to avoid blocking main operations
 	select {
 	case s.auditChan <- a:
 		return nil
 	default:
+		defer s.pendingAudits.Add(-1)
 		if err := s.persistAuditWithRetry(a); err != nil {
 			return fmt.Errorf("persist audit synchronously: %w", err)
 		}
@@ -300,27 +304,27 @@ func (s *SecurityService) processAuditEvents() {
 				// Channel closed, exit goroutine
 				return
 			}
-			if err := s.persistAuditWithRetry(audit); err != nil {
-				// Silently ignore errors from closed databases (common in tests)
-				// Only log for other types of errors
-				errMsg := err.Error()
-				if !strings.Contains(errMsg, "no such table") &&
-					!strings.Contains(errMsg, "database is closed") {
-					fmt.Printf("Failed to write audit log: %v\n", err)
-				}
-			}
+			s.handleAudit(audit)
 		case <-s.done:
 			// Service is shutting down - drain remaining audit events before exiting
 			for audit := range s.auditChan {
-				if err := s.persistAuditWithRetry(audit); err != nil {
-					errMsg := err.Error()
-					if !strings.Contains(errMsg, "no such table") &&
-						!strings.Contains(errMsg, "database is closed") {
-						fmt.Printf("Failed to write audit log: %v\n", err)
-					}
-				}
+				s.handleAudit(audit)
 			}
 			return
+		}
+	}
+}
+
+// handleAudit persists a dequeued audit and marks it no longer pending.
+func (s *SecurityService) handleAudit(audit *models.SecurityAudit) {
+	defer s.pendingAudits.Add(-1)
+	if err := s.persistAuditWithRetry(audit); err != nil {
+		// Silently ignore errors from closed databases (common in tests)
+		// Only log for other types of errors
+		errMsg := err.Error()
+		if !strings.Contains(errMsg, "no such table") &&
+			!strings.Contains(errMsg, "database is closed") {
+			fmt.Printf("Failed to write audit log: %v\n", err)
 		}
 	}
 }

--- a/backend/internal/services/security_service_test.go
+++ b/backend/internal/services/security_service_test.go
@@ -417,6 +417,36 @@ func TestSecurityService_Upsert_RateLimitFieldsPersist(t *testing.T) {
 	assert.Equal(t, "custom-rules", got.WAFRulesSource, "WAFRulesSource should be updated")
 }
 
+func TestSecurityService_Flush_WaitsForSlowWrites(t *testing.T) {
+	db := setupSecurityTestDB(t)
+
+	// Simulate a slow CI runner: each SecurityAudit INSERT takes 150ms, so
+	// three writes (450ms) exceed the old Flush cap of 200ms. Flush must
+	// still wait for every accepted audit to be persisted.
+	err := db.Callback().Create().Before("gorm:create").Register("test_slow_audit_insert", func(tx *gorm.DB) {
+		if _, ok := tx.Statement.Dest.(*models.SecurityAudit); ok {
+			time.Sleep(150 * time.Millisecond)
+		}
+	})
+	assert.NoError(t, err)
+
+	svc := newTestSecurityService(t, db)
+
+	for i := 0; i < 3; i++ {
+		assert.NoError(t, svc.LogAudit(&models.SecurityAudit{
+			Action:        fmt.Sprintf("slow_write_%d", i),
+			EventCategory: "flush_test",
+		}))
+	}
+
+	svc.Flush()
+
+	var count int64
+	assert.NoError(t, db.Model(&models.SecurityAudit{}).
+		Where("event_category = ?", "flush_test").Count(&count).Error)
+	assert.EqualValues(t, 3, count, "Flush returned before all pending audits were persisted")
+}
+
 func TestSecurityService_LogAudit(t *testing.T) {
 	db := setupSecurityTestDB(t)
 	svc := newTestSecurityService(t, db)

--- a/docs/features.md
+++ b/docs/features.md
@@ -279,7 +279,7 @@ Know immediately when something goes wrong. Charon continuously monitors your ap
 
 ### 📋 Real-Time Logs
 
-Watch requests flow through your proxy in real-time. Filter by domain, status code, or time range to troubleshoot issues quickly. All the visibility you need without diving into container logs.
+Watch requests flow through your proxy in real-time. Filter by domain, status code, or time range to troubleshoot issues quickly. All the visibility you need without diving into container logs. Need to look back? The Log Viewer on the Tasks → Logs page lets you browse saved log files — click any column header to sort them, and download a file with one click.
 
 → [Learn More](features/logs.md)
 

--- a/docs/features/logs.md
+++ b/docs/features/logs.md
@@ -67,6 +67,16 @@ If the WebSocket disconnects frequently:
 3. Ensure the Charon container has sufficient resources
 4. Check for network timeouts on long-idle connections
 
+## Browsing Saved Log Files
+
+Want to look at older logs instead of the live stream? Open the **Tasks → Logs** page. It shows saved log files in an easy-to-read table:
+
+- **Sort with a click** — Click a column header (Time, Level, Status, Method, or Path) to sort the table. Click it again to flip the order.
+- **Level at a glance** — A Level column shows how serious each entry is (info, warning, or error) without reading the whole line.
+- **Search and filter** — Type in the search box or pick a level to narrow things down, and use the page controls to move through long files.
+- **One-click download** — Save a log file to your computer. If a file can't be downloaded, you'll see a friendly message explaining what happened instead of a blank page.
+- **Handles messy files** — If a log file is huge or partly damaged, the viewer still shows everything it can read, along with a small notice telling you how many unreadable lines were skipped.
+
 ## Related
 
 - [WebSocket Support](websocket.md)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,7 +54,7 @@
         "@vitejs/plugin-react": "^6.0.3",
         "@vitest/coverage-istanbul": "^4.1.9",
         "@vitest/coverage-v8": "^4.1.9",
-        "@vitest/eslint-plugin": "^1.6.21",
+        "@vitest/eslint-plugin": "1.6.20",
         "@vitest/ui": "^4.1.9",
         "eslint": "^10.6.0",
         "eslint-formatter-compact": "^9.0.1",
@@ -1303,9 +1303,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1323,9 +1320,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1343,9 +1337,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1363,9 +1354,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1383,9 +1371,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1403,9 +1388,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1423,9 +1405,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1443,9 +1422,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1658,9 +1634,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1675,9 +1648,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1692,9 +1662,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1709,9 +1676,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1726,9 +1690,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1743,9 +1704,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1760,9 +1718,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1777,9 +1732,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2699,9 +2651,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2719,9 +2668,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2739,9 +2685,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2759,9 +2702,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2779,9 +2719,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2799,9 +2736,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3033,9 +2967,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3053,9 +2984,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3073,9 +3001,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3093,9 +3018,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4083,9 +4005,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4100,9 +4019,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4117,9 +4033,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4134,9 +4047,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4151,9 +4061,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4168,9 +4075,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4185,9 +4089,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4202,9 +4103,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4219,9 +4117,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4236,9 +4131,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4437,11 +4329,10 @@
       }
     },
     "node_modules/@vitest/eslint-plugin": {
-      "version": "1.6.21",
-      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.21.tgz",
-      "integrity": "sha512-5nu7QuW5Dg9v4I9t9ZiU1Hh91BoG0x3lOzOWYTsr1bqpIqcHYzFSQ052LvZwGtEm7Trh+Mr2heYEmZ4LkDjfaA==",
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.20.tgz",
+      "integrity": "sha512-xRwWHFG0Utp6hXtbGiWk4VdKXCGdExD8kbWrrmFEiG5dk8anOJ+vbWbeOa8EbkocKQRTsx7JAWETccZiBgFp/Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "^8.58.0",
         "@typescript-eslint/utils": "^8.58.0"
@@ -8152,9 +8043,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8176,9 +8064,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8200,9 +8085,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8224,9 +8106,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-istanbul": "^4.1.9",
     "@vitest/coverage-v8": "^4.1.9",
-    "@vitest/eslint-plugin": "^1.6.21",
+    "@vitest/eslint-plugin": "1.6.20",
     "@vitest/ui": "^4.1.9",
     "eslint": "^10.6.0",
     "eslint-formatter-compact": "^9.0.1",

--- a/frontend/src/api/__tests__/logs.http.test.ts
+++ b/frontend/src/api/__tests__/logs.http.test.ts
@@ -24,7 +24,7 @@ describe('logs api http helpers', () => {
     expect(logs[0].name).toBe('access.log')
     expect(client.get).toHaveBeenCalledWith('/logs')
 
-    vi.mocked(client.get).mockResolvedValueOnce({ data: { filename: 'access.log', logs: [], total: 0, limit: 100, offset: 0 } })
+    vi.mocked(client.get).mockResolvedValueOnce({ data: { filename: 'access.log', logs: [], total: 0, limit: 100, offset: 0, skipped_lines: 0 } })
     const resp = await getLogContent('access.log', {
       search: 'bot',
       host: 'example.com',
@@ -33,13 +33,32 @@ describe('logs api http helpers', () => {
       limit: 50,
       offset: 5,
       sort: 'asc',
+      sortBy: 'uri',
     })
     expect(resp.filename).toBe('access.log')
-    expect(client.get).toHaveBeenCalledWith('/logs/access.log?search=bot&host=example.com&status=500&level=error&limit=50&offset=5&sort=asc')
+    expect(client.get).toHaveBeenCalledWith('/logs/access.log?search=bot&host=example.com&status=500&level=error&limit=50&offset=5&sort=asc&sort_by=uri')
   })
 
-  it('downloads log via window location', () => {
-    downloadLog('access.log')
-    expect(window.location.href).toBe('/api/v1/logs/access.log/download')
+  it('downloads log as a blob without navigating', async () => {
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url')
+    URL.revokeObjectURL = vi.fn()
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+    try {
+      vi.mocked(client.get).mockResolvedValueOnce({ data: new Blob(['log content']) })
+
+      await downloadLog('access.log')
+
+      expect(client.get).toHaveBeenCalledWith('/logs/access.log/download', { responseType: 'blob' })
+      expect(clickSpy).toHaveBeenCalledTimes(1)
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+      expect(window.location.href).toBe('http://localhost')
+    } finally {
+      clickSpy.mockRestore()
+      URL.createObjectURL = originalCreateObjectURL
+      URL.revokeObjectURL = originalRevokeObjectURL
+    }
   })
 })

--- a/frontend/src/api/logs.test.ts
+++ b/frontend/src/api/logs.test.ts
@@ -80,7 +80,7 @@ describe('logs api', () => {
   })
 
   it('fetches log content with filters applied', async () => {
-    mockedClient.get.mockResolvedValue({ data: { filename: 'access.log', logs: [], total: 0, limit: 50, offset: 0 } })
+    mockedClient.get.mockResolvedValue({ data: { filename: 'access.log', logs: [], total: 0, limit: 50, offset: 0, skipped_lines: 0 } })
 
     await getLogContent('access.log', {
       search: 'error',
@@ -90,16 +90,81 @@ describe('logs api', () => {
       limit: 50,
       offset: 10,
       sort: 'asc',
+      sortBy: 'status',
     })
 
     expect(mockedClient.get).toHaveBeenCalledWith(
-      '/logs/access.log?search=error&host=example.com&status=500&level=error&limit=50&offset=10&sort=asc'
+      '/logs/access.log?search=error&host=example.com&status=500&level=error&limit=50&offset=10&sort=asc&sort_by=status'
     )
   })
 
-  it('sets window location when downloading logs', () => {
-    downloadLog('access.log')
-    expect(window.location.href).toBe('/api/v1/logs/access.log/download')
+  it('omits sort_by when not set and encodes the filename', async () => {
+    mockedClient.get.mockResolvedValue({ data: { filename: 'my log.log', logs: [], total: 0, limit: 50, offset: 0, skipped_lines: 0 } })
+
+    await getLogContent('my log.log', {})
+
+    expect(mockedClient.get).toHaveBeenCalledWith('/logs/my%20log.log?')
+  })
+
+  describe('downloadLog', () => {
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+
+    beforeEach(() => {
+      URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url')
+      URL.revokeObjectURL = vi.fn()
+    })
+
+    afterEach(() => {
+      URL.createObjectURL = originalCreateObjectURL
+      URL.revokeObjectURL = originalRevokeObjectURL
+    })
+
+    it('downloads the log as a blob via a temporary anchor', async () => {
+      const blob = new Blob(['log content'], { type: 'text/plain' })
+      mockedClient.get.mockResolvedValue({ data: blob })
+      const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+      await downloadLog('access.log')
+
+      expect(mockedClient.get).toHaveBeenCalledWith('/logs/access.log/download', { responseType: 'blob' })
+      expect(URL.createObjectURL).toHaveBeenCalledWith(blob)
+      expect(clickSpy).toHaveBeenCalledTimes(1)
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+
+      clickSpy.mockRestore()
+    })
+
+    it('encodes the filename in the download URL', async () => {
+      mockedClient.get.mockResolvedValue({ data: new Blob(['x']) })
+      const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+      await downloadLog('my log.log')
+
+      expect(mockedClient.get).toHaveBeenCalledWith('/logs/my%20log.log/download', { responseType: 'blob' })
+      clickSpy.mockRestore()
+    })
+
+    it('propagates errors to the caller without navigating', async () => {
+      const failure = new Error('Log file not found')
+      mockedClient.get.mockRejectedValue(failure)
+
+      await expect(downloadLog('missing.log')).rejects.toThrow('Log file not found')
+      expect(URL.createObjectURL).not.toHaveBeenCalled()
+      expect(window.location.href).toBe('')
+    })
+
+    it('revokes the object URL even when the anchor click throws', async () => {
+      mockedClient.get.mockResolvedValue({ data: new Blob(['x']) })
+      const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {
+        throw new Error('click failed')
+      })
+
+      await expect(downloadLog('access.log')).rejects.toThrow('click failed')
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+
+      clickSpy.mockRestore()
+    })
   })
 
   it('connects to live logs websocket and handles lifecycle events', () => {

--- a/frontend/src/api/logs.ts
+++ b/frontend/src/api/logs.ts
@@ -32,7 +32,12 @@ export interface LogResponse {
   total: number;
   limit: number;
   offset: number;
+  /** Number of corrupted/oversized lines skipped during parsing. */
+  skipped_lines: number;
 }
+
+/** Columns the backend can sort log entries by. */
+export type LogSortField = 'ts' | 'level' | 'method' | 'uri' | 'status';
 
 /** Filter options for log queries. */
 export interface LogFilter {
@@ -43,6 +48,7 @@ export interface LogFilter {
   limit?: number;
   offset?: number;
   sort?: 'asc' | 'desc';
+  sortBy?: LogSortField;
 }
 
 /**
@@ -71,20 +77,35 @@ export const getLogContent = async (filename: string, filter: LogFilter = {}): P
   if (filter.limit) params.append('limit', filter.limit.toString());
   if (filter.offset) params.append('offset', filter.offset.toString());
   if (filter.sort) params.append('sort', filter.sort);
+  if (filter.sortBy) params.append('sort_by', filter.sortBy);
 
-  const response = await client.get<LogResponse>(`/logs/${filename}?${params.toString()}`);
+  const response = await client.get<LogResponse>(`/logs/${encodeURIComponent(filename)}?${params.toString()}`);
   return response.data;
 };
 
 /**
- * Initiates a log file download by redirecting the browser.
+ * Downloads a log file as a blob and saves it via a temporary anchor element.
+ * Goes through the shared axios client so auth interceptors apply and HTTP
+ * errors reject instead of navigating the SPA to a JSON error body.
  * @param filename - The log file name to download
+ * @throws {AxiosError} If the download request fails
  */
-export const downloadLog = (filename: string) => {
-  // Direct window location change to trigger download
-  // We need to use the base URL from the client config if possible,
-  // but for now we assume relative path works with the proxy setup
-  window.location.href = `/api/v1/logs/${filename}/download`;
+export const downloadLog = async (filename: string): Promise<void> => {
+  const response = await client.get<Blob>(`/logs/${encodeURIComponent(filename)}/download`, {
+    responseType: 'blob',
+  });
+
+  const url = URL.createObjectURL(response.data);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  try {
+    anchor.click();
+  } finally {
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
 };
 
 /** Live log entry from WebSocket stream. */
@@ -162,11 +183,9 @@ export const connectLiveLogs = (
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
   const wsUrl = `${protocol}//${window.location.host}/api/v1/logs/live?${params.toString()}`;
 
-  console.log('Connecting to WebSocket:', wsUrl);
   const ws = new WebSocket(wsUrl);
 
   ws.onopen = () => {
-    console.log('WebSocket connection established');
     onOpen?.();
   };
 
@@ -184,8 +203,7 @@ export const connectLiveLogs = (
     onError?.(error);
   };
 
-  ws.onclose = (event: CloseEvent) => {
-    console.log('WebSocket connection closed', { code: event.code, reason: event.reason, wasClean: event.wasClean });
+  ws.onclose = () => {
     onClose?.();
   };
 
@@ -227,11 +245,9 @@ export const connectSecurityLogs = (
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
   const wsUrl = `${protocol}//${window.location.host}/api/v1/cerberus/logs/ws?${params.toString()}`;
 
-  console.log('Connecting to Cerberus logs WebSocket:', wsUrl);
   const ws = new WebSocket(wsUrl);
 
   ws.onopen = () => {
-    console.log('Cerberus logs WebSocket connection established');
     onOpen?.();
   };
 
@@ -249,8 +265,7 @@ export const connectSecurityLogs = (
     onError?.(error);
   };
 
-  ws.onclose = (event: CloseEvent) => {
-    console.log('Cerberus logs WebSocket closed', { code: event.code, reason: event.reason, wasClean: event.wasClean });
+  ws.onclose = () => {
     onClose?.();
   };
 

--- a/frontend/src/components/LogFilters.tsx
+++ b/frontend/src/components/LogFilters.tsx
@@ -12,8 +12,6 @@ interface LogFiltersProps {
   onLevelChange: (value: string) => void;
   host: string;
   onHostChange: (value: string) => void;
-  sort: 'asc' | 'desc';
-  onSortChange: (value: 'asc' | 'desc') => void;
   onRefresh: () => void;
   onDownload: () => void;
   isLoading: boolean;
@@ -28,8 +26,6 @@ export const LogFilters: React.FC<LogFiltersProps> = ({
   onLevelChange,
   host,
   onHostChange,
-  sort,
-  onSortChange,
   onRefresh,
   onDownload,
   isLoading
@@ -88,18 +84,6 @@ export const LogFilters: React.FC<LogFiltersProps> = ({
           <option value="3xx">3xx Redirect</option>
           <option value="4xx">4xx Client Error</option>
           <option value="5xx">5xx Server Error</option>
-        </select>
-      </div>
-
-      <div className="w-full md:w-32">
-        <select
-          value={sort}
-          onChange={(e) => onSortChange(e.target.value as 'asc' | 'desc')}
-          className="block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm dark:bg-gray-700 dark:text-white"
-          data-testid="sort-select"
-        >
-          <option value="desc">Newest First</option>
-          <option value="asc">Oldest First</option>
         </select>
       </div>
 

--- a/frontend/src/components/LogTable.tsx
+++ b/frontend/src/components/LogTable.tsx
@@ -1,18 +1,82 @@
 import { format } from 'date-fns';
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
-import { type CaddyAccessLog } from '../api/logs';
+import { type CaddyAccessLog, type LogSortField } from '../api/logs';
+
+type SortDirection = 'asc' | 'desc';
 
 interface LogTableProps {
   logs: CaddyAccessLog[];
   isLoading: boolean;
+  /** True while a background refetch is in flight (previous page still shown). */
+  isFetching?: boolean;
+  sortBy: LogSortField;
+  sortDir: SortDirection;
+  onSortChange: (field: LogSortField) => void;
 }
 
-export const LogTable: React.FC<LogTableProps> = ({ logs, isLoading }) => {
+const HEADER_CELL_CLASS =
+  'px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 tracking-wider';
+
+/** Badge color classes per log level (unknown levels fall back to gray). */
+const LEVEL_BADGE_CLASSES: Record<string, string> = {
+  error: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  warn: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  info: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  debug: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+};
+
+interface SortableHeaderProps {
+  field: LogSortField;
+  label: string;
+  sortBy: LogSortField;
+  sortDir: SortDirection;
+  onSortChange: (field: LogSortField) => void;
+}
+
+/**
+ * Clickable column header for server-side sorting. The header keeps the
+ * plain label as its accessible name (button text only), exposes the active
+ * sort via aria-sort on the th, and shows a direction icon.
+ */
+const SortableHeader: React.FC<SortableHeaderProps> = ({ field, label, sortBy, sortDir, onSortChange }) => {
+  const isActive = sortBy === field;
+  const ariaSort = isActive ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined;
+  const Icon = isActive ? (sortDir === 'asc' ? ArrowUp : ArrowDown) : ArrowUpDown;
+
+  return (
+    <th className={HEADER_CELL_CLASS} aria-sort={ariaSort}>
+      <button
+        type="button"
+        onClick={() => onSortChange(field)}
+        data-testid={`sort-header-${field}`}
+        className={`inline-flex items-center gap-1 hover:text-gray-700 dark:hover:text-gray-200 transition-colors ${
+          isActive ? 'text-gray-900 dark:text-white' : ''
+        }`}
+      >
+        {label}
+        <Icon className="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
+    </th>
+  );
+};
+
+export const LogTable: React.FC<LogTableProps> = ({
+  logs,
+  isLoading,
+  isFetching = false,
+  sortBy,
+  sortDir,
+  onSortChange,
+}) => {
+  const { t } = useTranslation();
+
   if (isLoading) {
     return (
       <div className="w-full h-64 flex items-center justify-center text-gray-500">
-        Loading logs...
+        {t('logs.loading')}
       </div>
     );
   }
@@ -20,27 +84,34 @@ export const LogTable: React.FC<LogTableProps> = ({ logs, isLoading }) => {
   if (!logs || logs.length === 0) {
     return (
       <div className="w-full h-64 flex items-center justify-center text-gray-500">
-        No logs found matching criteria.
+        {t('logs.noLogsFound')}
       </div>
     );
   }
+
+  const sortProps = { sortBy, sortDir, onSortChange };
 
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead className="bg-gray-50 dark:bg-gray-800">
           <tr>
-            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Time</th>
-            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
-            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Method</th>
-            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Host</th>
-            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Path</th>
-            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">IP</th>
-            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Latency</th>
-            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Message</th>
+            <SortableHeader field="ts" label={t('logs.columnTime')} {...sortProps} />
+            <SortableHeader field="level" label={t('logs.columnLevel')} {...sortProps} />
+            <SortableHeader field="status" label={t('logs.columnStatus')} {...sortProps} />
+            <SortableHeader field="method" label={t('logs.columnMethod')} {...sortProps} />
+            <th className={HEADER_CELL_CLASS}>{t('logs.columnHost')}</th>
+            <SortableHeader field="uri" label={t('logs.columnPath')} {...sortProps} />
+            <th className={HEADER_CELL_CLASS}>{t('logs.columnIp')}</th>
+            <th className={HEADER_CELL_CLASS}>{t('logs.columnLatency')}</th>
+            <th className={HEADER_CELL_CLASS}>{t('logs.columnMessage')}</th>
           </tr>
         </thead>
-        <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+        <tbody
+          className={`bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700 transition-opacity ${
+            isFetching ? 'opacity-50' : ''
+          }`}
+        >
           {logs.map((log, idx) => {
             // Check if this is a structured access log or a plain text system log
             const isAccessLog = log.status > 0 || (log.request && log.request.method);
@@ -51,7 +122,7 @@ export const LogTable: React.FC<LogTableProps> = ({ logs, isLoading }) => {
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                     {format(new Date(log.ts * 1000), 'MMM d HH:mm:ss')}
                   </td>
-                  <td colSpan={7} className="px-6 py-4 text-sm text-gray-900 dark:text-white font-mono whitespace-pre-wrap break-all">
+                  <td colSpan={8} className="px-6 py-4 text-sm text-gray-900 dark:text-white font-mono whitespace-pre-wrap break-all">
                     {log.msg}
                   </td>
                 </tr>
@@ -62,6 +133,18 @@ export const LogTable: React.FC<LogTableProps> = ({ logs, isLoading }) => {
             <tr key={idx} className="hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
               <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                 {format(new Date(log.ts * 1000), 'MMM d HH:mm:ss')}
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm">
+                {log.level && (
+                  <span
+                    className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full uppercase ${
+                      LEVEL_BADGE_CLASSES[log.level.toLowerCase()] ?? LEVEL_BADGE_CLASSES.debug
+                    }`}
+                    data-testid={`level-${log.level.toLowerCase()}`}
+                  >
+                    {log.level}
+                  </span>
+                )}
               </td>
               <td className="px-6 py-4 whitespace-nowrap text-sm">
                 {log.status > 0 && (

--- a/frontend/src/components/LogTable.tsx
+++ b/frontend/src/components/LogTable.tsx
@@ -47,7 +47,7 @@ const SortableHeader: React.FC<SortableHeaderProps> = ({ field, label, sortBy, s
   const Icon = isActive ? (sortDir === 'asc' ? ArrowUp : ArrowDown) : ArrowUpDown;
 
   return (
-    <th className={HEADER_CELL_CLASS} aria-sort={ariaSort}>
+    <th scope="col" className={HEADER_CELL_CLASS} aria-sort={ariaSort}>
       <button
         type="button"
         onClick={() => onSortChange(field)}
@@ -93,18 +93,21 @@ export const LogTable: React.FC<LogTableProps> = ({
 
   return (
     <div className="overflow-x-auto">
-      <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <table
+        className="min-w-full divide-y divide-gray-200 dark:divide-gray-700"
+        aria-busy={isFetching}
+      >
         <thead className="bg-gray-50 dark:bg-gray-800">
           <tr>
             <SortableHeader field="ts" label={t('logs.columnTime')} {...sortProps} />
             <SortableHeader field="level" label={t('logs.columnLevel')} {...sortProps} />
             <SortableHeader field="status" label={t('logs.columnStatus')} {...sortProps} />
             <SortableHeader field="method" label={t('logs.columnMethod')} {...sortProps} />
-            <th className={HEADER_CELL_CLASS}>{t('logs.columnHost')}</th>
+            <th scope="col" className={HEADER_CELL_CLASS}>{t('logs.columnHost')}</th>
             <SortableHeader field="uri" label={t('logs.columnPath')} {...sortProps} />
-            <th className={HEADER_CELL_CLASS}>{t('logs.columnIp')}</th>
-            <th className={HEADER_CELL_CLASS}>{t('logs.columnLatency')}</th>
-            <th className={HEADER_CELL_CLASS}>{t('logs.columnMessage')}</th>
+            <th scope="col" className={HEADER_CELL_CLASS}>{t('logs.columnIp')}</th>
+            <th scope="col" className={HEADER_CELL_CLASS}>{t('logs.columnLatency')}</th>
+            <th scope="col" className={HEADER_CELL_CLASS}>{t('logs.columnMessage')}</th>
           </tr>
         </thead>
         <tbody

--- a/frontend/src/components/__tests__/LogFilters.test.tsx
+++ b/frontend/src/components/__tests__/LogFilters.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+import { LogFilters } from '../LogFilters'
+
+const defaultProps = {
+  search: '',
+  onSearchChange: vi.fn(),
+  status: '',
+  onStatusChange: vi.fn(),
+  level: '',
+  onLevelChange: vi.fn(),
+  host: '',
+  onHostChange: vi.fn(),
+  onRefresh: vi.fn(),
+  onDownload: vi.fn(),
+  isLoading: false,
+}
+
+describe('LogFilters', () => {
+  it('does not render the removed sort-select dropdown', () => {
+    render(<LogFilters {...defaultProps} />)
+    expect(screen.queryByTestId('sort-select')).not.toBeInTheDocument()
+  })
+
+  it('renders all remaining filter controls with their testids', () => {
+    render(<LogFilters {...defaultProps} />)
+
+    expect(screen.getByTestId('search-input')).toBeInTheDocument()
+    expect(screen.getByTestId('host-input')).toBeInTheDocument()
+    expect(screen.getByTestId('level-select')).toBeInTheDocument()
+    expect(screen.getByTestId('status-select')).toBeInTheDocument()
+    expect(screen.getByTestId('refresh-button')).toBeInTheDocument()
+    expect(screen.getByTestId('download-button')).toBeInTheDocument()
+  })
+
+  it('fires onSearchChange when typing in the search input', () => {
+    const onSearchChange = vi.fn()
+    render(<LogFilters {...defaultProps} onSearchChange={onSearchChange} />)
+
+    fireEvent.change(screen.getByTestId('search-input'), { target: { value: 'error' } })
+    expect(onSearchChange).toHaveBeenCalledWith('error')
+  })
+
+  it('fires onHostChange when typing in the host input', () => {
+    const onHostChange = vi.fn()
+    render(<LogFilters {...defaultProps} onHostChange={onHostChange} />)
+
+    fireEvent.change(screen.getByTestId('host-input'), { target: { value: 'example.com' } })
+    expect(onHostChange).toHaveBeenCalledWith('example.com')
+  })
+
+  it('fires onLevelChange when selecting a level', () => {
+    const onLevelChange = vi.fn()
+    render(<LogFilters {...defaultProps} onLevelChange={onLevelChange} />)
+
+    fireEvent.change(screen.getByTestId('level-select'), { target: { value: 'ERROR' } })
+    expect(onLevelChange).toHaveBeenCalledWith('ERROR')
+  })
+
+  it('fires onStatusChange when selecting a status class', () => {
+    const onStatusChange = vi.fn()
+    render(<LogFilters {...defaultProps} onStatusChange={onStatusChange} />)
+
+    fireEvent.change(screen.getByTestId('status-select'), { target: { value: '5xx' } })
+    expect(onStatusChange).toHaveBeenCalledWith('5xx')
+  })
+
+  it('fires onRefresh and onDownload from the action buttons', () => {
+    const onRefresh = vi.fn()
+    const onDownload = vi.fn()
+    render(<LogFilters {...defaultProps} onRefresh={onRefresh} onDownload={onDownload} />)
+
+    fireEvent.click(screen.getByTestId('refresh-button'))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByTestId('download-button'))
+    expect(onDownload).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/__tests__/LogTable.test.tsx
+++ b/frontend/src/components/__tests__/LogTable.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+import { type CaddyAccessLog } from '../../api/logs'
+import { LogTable } from '../LogTable'
+
+const accessLog = (overrides: Partial<CaddyAccessLog> = {}): CaddyAccessLog => ({
+  level: 'info',
+  ts: 1751630400,
+  logger: 'http.log.access',
+  msg: 'handled request',
+  request: {
+    remote_ip: '192.168.1.100',
+    method: 'GET',
+    host: 'api.example.com',
+    uri: '/api/v1/users',
+    proto: 'HTTP/2',
+  },
+  status: 200,
+  duration: 0.045,
+  size: 1234,
+  ...overrides,
+})
+
+const defaultProps = {
+  isLoading: false,
+  sortBy: 'ts' as const,
+  sortDir: 'desc' as const,
+  onSortChange: vi.fn(),
+}
+
+describe('LogTable', () => {
+  it('shows the translated loading state', () => {
+    render(<LogTable {...defaultProps} logs={[]} isLoading />)
+    expect(screen.getByText('Loading logs...')).toBeInTheDocument()
+  })
+
+  it('shows an empty state matching the E2E regex', () => {
+    render(<LogTable {...defaultProps} logs={[]} />)
+    expect(screen.getByText(/no logs found|no.*matching/i)).toBeInTheDocument()
+  })
+
+  it('keeps the plain column labels as columnheader accessible names', () => {
+    render(<LogTable {...defaultProps} logs={[accessLog()]} />)
+
+    // Regression guard: E2E locates headers via getByRole('columnheader', { name })
+    expect(screen.getByRole('columnheader', { name: 'Time' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Level' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Method' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Host' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Path' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /time/i })).toBeInTheDocument()
+  })
+
+  it('renders sort buttons with sort-header testids for each sortable column', () => {
+    render(<LogTable {...defaultProps} logs={[accessLog()]} />)
+
+    for (const field of ['ts', 'level', 'status', 'method', 'uri']) {
+      expect(screen.getByTestId(`sort-header-${field}`)).toBeInTheDocument()
+    }
+    expect(screen.queryByTestId('sort-header-host')).not.toBeInTheDocument()
+  })
+
+  it('sets aria-sort descending only on the active column', () => {
+    render(<LogTable {...defaultProps} logs={[accessLog()]} sortBy="ts" sortDir="desc" />)
+
+    expect(screen.getByRole('columnheader', { name: 'Time' })).toHaveAttribute('aria-sort', 'descending')
+    expect(screen.getByRole('columnheader', { name: 'Status' })).not.toHaveAttribute('aria-sort')
+    expect(screen.getByRole('columnheader', { name: 'Level' })).not.toHaveAttribute('aria-sort')
+  })
+
+  it('sets aria-sort ascending when the active direction is asc', () => {
+    render(<LogTable {...defaultProps} logs={[accessLog()]} sortBy="status" sortDir="asc" />)
+
+    expect(screen.getByRole('columnheader', { name: 'Status' })).toHaveAttribute('aria-sort', 'ascending')
+    expect(screen.getByRole('columnheader', { name: 'Time' })).not.toHaveAttribute('aria-sort')
+  })
+
+  it('invokes onSortChange with the field when a header button is clicked', () => {
+    const onSortChange = vi.fn()
+    render(<LogTable {...defaultProps} logs={[accessLog()]} onSortChange={onSortChange} />)
+
+    fireEvent.click(screen.getByTestId('sort-header-status'))
+    expect(onSortChange).toHaveBeenCalledWith('status')
+
+    fireEvent.click(screen.getByTestId('sort-header-uri'))
+    expect(onSortChange).toHaveBeenCalledWith('uri')
+  })
+
+  it('renders level badges with level testids and colors', () => {
+    render(
+      <LogTable
+        {...defaultProps}
+        logs={[
+          accessLog({ level: 'error', status: 500 }),
+          accessLog({ level: 'warn', status: 429 }),
+          accessLog({ level: 'info', status: 200 }),
+          accessLog({ level: 'debug', status: 204 }),
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('level-error')).toHaveClass('bg-red-100')
+    expect(screen.getByTestId('level-warn')).toHaveClass('bg-yellow-100')
+    expect(screen.getByTestId('level-info')).toHaveClass('bg-blue-100')
+    expect(screen.getByTestId('level-debug')).toHaveClass('bg-gray-100')
+  })
+
+  it('falls back to the gray badge for unknown levels', () => {
+    render(<LogTable {...defaultProps} logs={[accessLog({ level: 'TRACE' })]} />)
+    expect(screen.getByTestId('level-trace')).toHaveClass('bg-gray-100')
+  })
+
+  it('highlights 5xx status badges with red styling', () => {
+    render(<LogTable {...defaultProps} logs={[accessLog({ status: 502 })]} />)
+
+    // Protects the E2E assertion toHaveClass(/red/)
+    expect(screen.getByTestId('status-502').className).toMatch(/red/)
+  })
+
+  it('renders plain-text system log rows across the full width', () => {
+    const plainLog = accessLog({
+      status: 0,
+      msg: 'server started on :8080',
+      request: undefined as unknown as CaddyAccessLog['request'],
+    })
+    render(<LogTable {...defaultProps} logs={[plainLog]} />)
+
+    const wideCell = screen.getByText('server started on :8080')
+    expect(wideCell).toHaveAttribute('colspan', '8')
+  })
+
+  it('dims the table body while a background refetch is in flight', () => {
+    const { container, rerender } = render(
+      <LogTable {...defaultProps} logs={[accessLog()]} isFetching />
+    )
+    expect(container.querySelector('tbody')).toHaveClass('opacity-50')
+
+    rerender(<LogTable {...defaultProps} logs={[accessLog()]} isFetching={false} />)
+    expect(container.querySelector('tbody')).not.toHaveClass('opacity-50')
+  })
+
+  it('renders request details in access log rows', () => {
+    render(<LogTable {...defaultProps} logs={[accessLog()]} />)
+
+    expect(screen.getByText('GET')).toBeInTheDocument()
+    expect(screen.getByText('api.example.com')).toBeInTheDocument()
+    expect(screen.getByText('/api/v1/users')).toBeInTheDocument()
+    expect(screen.getByText('192.168.1.100')).toBeInTheDocument()
+    expect(screen.getByText('45.00ms')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/LogTable.test.tsx
+++ b/frontend/src/components/__tests__/LogTable.test.tsx
@@ -141,6 +141,24 @@ describe('LogTable', () => {
     expect(container.querySelector('tbody')).not.toHaveClass('opacity-50')
   })
 
+  it('marks the table aria-busy while a background refetch is in flight', () => {
+    const { rerender } = render(
+      <LogTable {...defaultProps} logs={[accessLog()]} isFetching />
+    )
+    expect(screen.getByRole('table')).toHaveAttribute('aria-busy', 'true')
+
+    rerender(<LogTable {...defaultProps} logs={[accessLog()]} isFetching={false} />)
+    expect(screen.getByRole('table')).toHaveAttribute('aria-busy', 'false')
+  })
+
+  it('sets scope="col" on every column header', () => {
+    render(<LogTable {...defaultProps} logs={[accessLog()]} />)
+
+    const headers = screen.getAllByRole('columnheader')
+    expect(headers).toHaveLength(9)
+    headers.forEach((th) => expect(th).toHaveAttribute('scope', 'col'))
+  })
+
   it('renders request details in access log rows', () => {
     render(<LogTable {...defaultProps} logs={[accessLog()]} />)
 

--- a/frontend/src/hooks/__tests__/useDebouncedValue.test.ts
+++ b/frontend/src/hooks/__tests__/useDebouncedValue.test.ts
@@ -1,0 +1,88 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { useDebouncedValue } from '../useDebouncedValue'
+
+describe('useDebouncedValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebouncedValue('initial'))
+    expect(result.current).toBe('initial')
+  })
+
+  it('does not update before the delay has elapsed', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value), {
+      initialProps: { value: 'a' },
+    })
+
+    rerender({ value: 'b' })
+    act(() => {
+      vi.advanceTimersByTime(299)
+    })
+
+    expect(result.current).toBe('a')
+  })
+
+  it('updates after the default 300ms delay', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value), {
+      initialProps: { value: 'a' },
+    })
+
+    rerender({ value: 'b' })
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(result.current).toBe('b')
+  })
+
+  it('restarts the timer on rapid changes and only emits the last value', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value), {
+      initialProps: { value: 'a' },
+    })
+
+    rerender({ value: 'b' })
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    rerender({ value: 'c' })
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    expect(result.current).toBe('a')
+
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(result.current).toBe('c')
+  })
+
+  it('honors a custom delay', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 50), {
+      initialProps: { value: 1 },
+    })
+
+    rerender({ value: 2 })
+    act(() => {
+      vi.advanceTimersByTime(50)
+    })
+
+    expect(result.current).toBe(2)
+  })
+
+  it('cleans up the pending timer on unmount', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const { unmount, rerender } = renderHook(({ value }) => useDebouncedValue(value), {
+      initialProps: { value: 'a' },
+    })
+
+    rerender({ value: 'b' })
+    unmount()
+
+    expect(clearSpy).toHaveBeenCalled()
+    clearSpy.mockRestore()
+  })
+})

--- a/frontend/src/hooks/__tests__/useLogs.test.tsx
+++ b/frontend/src/hooks/__tests__/useLogs.test.tsx
@@ -1,0 +1,149 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import toast from 'react-hot-toast'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { getLogs, getLogContent, downloadLog, type LogResponse } from '../../api/logs'
+import { logKeys, useLogFiles, useLogContent, useDownloadLog } from '../useLogs'
+
+vi.mock('../../api/logs', () => ({
+  getLogs: vi.fn(),
+  getLogContent: vi.fn(),
+  downloadLog: vi.fn(),
+}))
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+const mockFiles = [{ name: 'access.log', size: 1024, mod_time: '2026-07-04T00:00:00Z' }]
+
+const mockResponse: LogResponse = {
+  filename: 'access.log',
+  logs: [],
+  total: 0,
+  limit: 50,
+  offset: 0,
+  skipped_lines: 0,
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('logKeys', () => {
+  it('builds stable query keys', () => {
+    expect(logKeys.all).toEqual(['logs'])
+    expect(logKeys.content('access.log', { limit: 50 })).toEqual(['logs', 'access.log', { limit: 50 }])
+  })
+})
+
+describe('useLogFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches the log file list', async () => {
+    vi.mocked(getLogs).mockResolvedValue(mockFiles)
+
+    const { result } = renderHook(() => useLogFiles(), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(getLogs).toHaveBeenCalledTimes(1)
+    expect(result.current.data).toEqual(mockFiles)
+  })
+})
+
+describe('useLogContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches log content for a selected file', async () => {
+    vi.mocked(getLogContent).mockResolvedValue(mockResponse)
+
+    const { result } = renderHook(
+      () => useLogContent('access.log', { limit: 50, offset: 0, sort: 'desc', sortBy: 'ts' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(getLogContent).toHaveBeenCalledWith('access.log', { limit: 50, offset: 0, sort: 'desc', sortBy: 'ts' })
+    expect(result.current.data).toEqual(mockResponse)
+  })
+
+  it('is disabled when no filename is selected', async () => {
+    const { result } = renderHook(() => useLogContent(null, {}), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe('idle'))
+    expect(getLogContent).not.toHaveBeenCalled()
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('keeps previous data while a new page is fetched', async () => {
+    vi.mocked(getLogContent).mockResolvedValue(mockResponse)
+
+    const wrapper = createWrapper()
+    const { result, rerender } = renderHook(
+      ({ offset }: { offset: number }) => useLogContent('access.log', { limit: 50, offset }),
+      { wrapper, initialProps: { offset: 0 } }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    let resolveSecond: (value: LogResponse) => void = () => {}
+    vi.mocked(getLogContent).mockImplementation(
+      () => new Promise((resolve) => { resolveSecond = resolve })
+    )
+
+    rerender({ offset: 50 })
+
+    // Previous page stays rendered as placeholder data while fetching
+    expect(result.current.data).toEqual(mockResponse)
+    expect(result.current.isPlaceholderData).toBe(true)
+    expect(result.current.isFetching).toBe(true)
+
+    resolveSecond({ ...mockResponse, offset: 50 })
+    await waitFor(() => expect(result.current.isPlaceholderData).toBe(false))
+    expect(result.current.data?.offset).toBe(50)
+  })
+})
+
+describe('useDownloadLog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('invokes downloadLog with the filename on mutate', async () => {
+    vi.mocked(downloadLog).mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useDownloadLog(), { wrapper: createWrapper() })
+
+    result.current.mutate('access.log')
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(downloadLog).toHaveBeenCalledWith('access.log')
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('shows a translated error toast when the download fails', async () => {
+    vi.mocked(downloadLog).mockRejectedValue(new Error('boom'))
+
+    const { result } = renderHook(() => useDownloadLog(), { wrapper: createWrapper() })
+
+    result.current.mutate('access.log')
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(toast.error).toHaveBeenCalledWith('Failed to download log file')
+  })
+})

--- a/frontend/src/hooks/useDebouncedValue.ts
+++ b/frontend/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a debounced copy of a value that only updates after the value
+ * has stayed unchanged for the given delay. Used to avoid firing a server
+ * query on every keystroke of a search input.
+ * @param value - The rapidly changing source value
+ * @param delayMs - Debounce delay in milliseconds (default 300)
+ * @returns The debounced value
+ */
+export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/frontend/src/hooks/useLogs.ts
+++ b/frontend/src/hooks/useLogs.ts
@@ -1,0 +1,65 @@
+import { keepPreviousData, useMutation, useQuery } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+
+import {
+  downloadLog,
+  getLogContent,
+  getLogs,
+  type LogFile,
+  type LogFilter,
+  type LogResponse,
+  type LogSortField,
+} from '../api/logs';
+
+/** Query key factory for log queries. */
+export const logKeys = {
+  all: ['logs'] as const,
+  content: (filename: string, filter: LogFilter) => ['logs', filename, filter] as const,
+};
+
+/**
+ * Hook for fetching the list of available log files.
+ * @returns Query result with the LogFile array
+ */
+export function useLogFiles() {
+  return useQuery({
+    queryKey: logKeys.all,
+    queryFn: getLogs,
+  });
+}
+
+/**
+ * Hook for fetching paginated, filtered, sorted log content.
+ * Keeps the previous page rendered while the next one loads so page
+ * flips and sort changes don't flash the loading skeleton.
+ * @param filename - Selected log file, or null when none selected
+ * @param filter - Server-side filter, pagination, and sort options
+ * @returns Query result with the LogResponse
+ */
+export function useLogContent(filename: string | null, filter: LogFilter) {
+  return useQuery<LogResponse>({
+    queryKey: logKeys.content(filename ?? '', filter),
+    queryFn: () => getLogContent(filename!, filter),
+    enabled: !!filename,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/**
+ * Hook for downloading a log file as a blob.
+ * Shows an error toast and keeps the user on the page when the download fails.
+ * @returns Mutation taking the log filename
+ */
+export function useDownloadLog() {
+  const { t } = useTranslation();
+
+  return useMutation<void, Error, string>({
+    mutationFn: (filename: string) => downloadLog(filename),
+    onError: () => {
+      toast.error(t('logs.downloadFailed'));
+    },
+  });
+}
+
+export type { LogFile, LogFilter, LogResponse, LogSortField };

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -813,7 +813,21 @@
     "noLogSelected": "Kein Protokoll ausgewählt",
     "selectLogDescription": "Wählen Sie eine Protokolldatei aus der Liste, um deren Inhalt anzuzeigen",
     "showingEntries": "Zeige {{from}} bis {{to}} von {{total}} Einträgen",
-    "pageOf": "Seite {{current}} von {{total}}"
+    "pageOf": "Seite {{current}} von {{total}}",
+    "loading": "Protokolle werden geladen...",
+    "noLogsFound": "Keine passenden Protokolleinträge gefunden.",
+    "downloadFailed": "Protokolldatei konnte nicht heruntergeladen werden",
+    "skippedLines_one": "{{count}} beschädigte oder übergroße Zeile wurde übersprungen",
+    "skippedLines_other": "{{count}} beschädigte oder übergroße Zeilen wurden übersprungen",
+    "columnTime": "Zeit",
+    "columnLevel": "Stufe",
+    "columnStatus": "Status",
+    "columnMethod": "Methode",
+    "columnHost": "Host",
+    "columnPath": "Pfad",
+    "columnIp": "IP",
+    "columnLatency": "Latenz",
+    "columnMessage": "Nachricht"
   },
   "account": {
     "title": "Kontoeinstellungen",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -981,7 +981,21 @@
     "noLogSelected": "No Log Selected",
     "selectLogDescription": "Select a log file from the list to view its contents",
     "showingEntries": "Showing {{from}} to {{to}} of {{total}} entries",
-    "pageOf": "Page {{current}} of {{total}}"
+    "pageOf": "Page {{current}} of {{total}}",
+    "loading": "Loading logs...",
+    "noLogsFound": "No logs found matching criteria.",
+    "downloadFailed": "Failed to download log file",
+    "skippedLines_one": "{{count}} corrupted or oversized line was skipped",
+    "skippedLines_other": "{{count}} corrupted or oversized lines were skipped",
+    "columnTime": "Time",
+    "columnLevel": "Level",
+    "columnStatus": "Status",
+    "columnMethod": "Method",
+    "columnHost": "Host",
+    "columnPath": "Path",
+    "columnIp": "IP",
+    "columnLatency": "Latency",
+    "columnMessage": "Message"
   },
   "account": {
     "title": "Account Settings",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -813,7 +813,21 @@
     "noLogSelected": "Ningún Registro Seleccionado",
     "selectLogDescription": "Seleccione un archivo de registro de la lista para ver su contenido",
     "showingEntries": "Mostrando {{from}} a {{to}} de {{total}} entradas",
-    "pageOf": "Página {{current}} de {{total}}"
+    "pageOf": "Página {{current}} de {{total}}",
+    "loading": "Cargando registros...",
+    "noLogsFound": "No se encontraron registros que coincidan con los criterios.",
+    "downloadFailed": "Error al descargar el archivo de registro",
+    "skippedLines_one": "Se omitió {{count}} línea dañada o demasiado grande",
+    "skippedLines_other": "Se omitieron {{count}} líneas dañadas o demasiado grandes",
+    "columnTime": "Tiempo",
+    "columnLevel": "Nivel",
+    "columnStatus": "Estado",
+    "columnMethod": "Método",
+    "columnHost": "Host",
+    "columnPath": "Ruta",
+    "columnIp": "IP",
+    "columnLatency": "Latencia",
+    "columnMessage": "Mensaje"
   },
   "account": {
     "title": "Configuración de Cuenta",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -813,7 +813,21 @@
     "noLogSelected": "Aucun Journal Sélectionné",
     "selectLogDescription": "Sélectionnez un fichier journal dans la liste pour voir son contenu",
     "showingEntries": "Affichage de {{from}} à {{to}} sur {{total}} entrées",
-    "pageOf": "Page {{current}} sur {{total}}"
+    "pageOf": "Page {{current}} sur {{total}}",
+    "loading": "Chargement des journaux...",
+    "noLogsFound": "Aucun journal ne correspond aux critères.",
+    "downloadFailed": "Échec du téléchargement du fichier journal",
+    "skippedLines_one": "{{count}} ligne corrompue ou trop longue a été ignorée",
+    "skippedLines_other": "{{count}} lignes corrompues ou trop longues ont été ignorées",
+    "columnTime": "Heure",
+    "columnLevel": "Niveau",
+    "columnStatus": "Statut",
+    "columnMethod": "Méthode",
+    "columnHost": "Hôte",
+    "columnPath": "Chemin",
+    "columnIp": "IP",
+    "columnLatency": "Latence",
+    "columnMessage": "Message"
   },
   "account": {
     "title": "Paramètres du Compte",

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -813,7 +813,20 @@
     "noLogSelected": "未选择日志",
     "selectLogDescription": "从列表中选择一个日志文件以查看其内容",
     "showingEntries": "显示 {{from}} 到 {{to}} 共 {{total}} 条",
-    "pageOf": "第 {{current}} 页，共 {{total}} 页"
+    "pageOf": "第 {{current}} 页，共 {{total}} 页",
+    "loading": "正在加载日志...",
+    "noLogsFound": "未找到符合条件的日志。",
+    "downloadFailed": "日志文件下载失败",
+    "skippedLines_other": "已跳过 {{count}} 行损坏或过大的日志",
+    "columnTime": "时间",
+    "columnLevel": "级别",
+    "columnStatus": "状态",
+    "columnMethod": "方法",
+    "columnHost": "主机",
+    "columnPath": "路径",
+    "columnIp": "IP",
+    "columnLatency": "延迟",
+    "columnMessage": "消息"
   },
   "account": {
     "title": "账户设置",

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -1,10 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
-import { FileText, ChevronLeft, ChevronRight, ScrollText } from 'lucide-react';
+import { FileText, ChevronLeft, ChevronRight, ScrollText, AlertTriangle } from 'lucide-react';
 import { useState, useEffect, type FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
-import { getLogs, getLogContent, downloadLog, type LogFilter } from '../api/logs';
+import { type LogFilter, type LogSortField } from '../api/logs';
 import { PageShell } from '../components/layout/PageShell';
 import { LogFilters } from '../components/LogFilters';
 import { LogTable } from '../components/LogTable';
@@ -16,6 +15,8 @@ import {
   Skeleton,
   SkeletonList,
 } from '../components/ui';
+import { useDebouncedValue } from '../hooks/useDebouncedValue';
+import { useDownloadLog, useLogContent, useLogFiles } from '../hooks/useLogs';
 
 const Logs: FC = () => {
   const { t } = useTranslation();
@@ -27,14 +28,21 @@ const Logs: FC = () => {
   const [host, setHost] = useState('');
   const [status, setStatus] = useState('');
   const [level, setLevel] = useState('');
-  const [sort, setSort] = useState<'asc' | 'desc'>('desc');
+  const [sortBy, setSortBy] = useState<LogSortField>('ts');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
   const [page, setPage] = useState(0);
   const limit = 50;
 
-  const { data: logs, isLoading: isLoadingLogs } = useQuery({
-    queryKey: ['logs'],
-    queryFn: getLogs,
-  });
+  const debouncedSearch = useDebouncedValue(search);
+  const debouncedHost = useDebouncedValue(host);
+
+  // Reset pagination only once the debounced values change, so a keystroke
+  // doesn't reset the page before the query actually fires.
+  useEffect(() => {
+    setPage(0);
+  }, [debouncedSearch, debouncedHost]);
+
+  const { data: logs, isLoading: isLoadingLogs } = useLogFiles();
 
   // Select first log by default if none selected
   useEffect(() => {
@@ -44,23 +52,37 @@ const Logs: FC = () => {
   }, [logs, selectedLog]);
 
   const filter: LogFilter = {
-    search,
-    host,
+    search: debouncedSearch,
+    host: debouncedHost,
     status,
     level,
     limit,
     offset: page * limit,
-    sort,
+    sort: sortDir,
+    sortBy,
   };
 
-  const { data: logData, isLoading: isLoadingContent, refetch: refetchContent } = useQuery({
-    queryKey: ['logContent', selectedLog, search, host, status, level, page, sort],
-    queryFn: () => (selectedLog ? getLogContent(selectedLog, filter) : Promise.resolve(null)),
-    enabled: !!selectedLog,
-  });
+  const {
+    data: logData,
+    isLoading: isLoadingContent,
+    isFetching: isFetchingContent,
+    refetch: refetchContent,
+  } = useLogContent(selectedLog, filter);
+
+  const downloadMutation = useDownloadLog();
 
   const handleDownload = () => {
-    if (selectedLog) downloadLog(selectedLog);
+    if (selectedLog) downloadMutation.mutate(selectedLog);
+  };
+
+  const handleSortChange = (field: LogSortField) => {
+    if (field === sortBy) {
+      setSortDir((d) => (d === 'desc' ? 'asc' : 'desc'));
+    } else {
+      setSortBy(field);
+      setSortDir('desc');
+    }
+    setPage(0);
   };
 
   const totalPages = logData ? Math.ceil(logData.total / limit) : 0;
@@ -113,15 +135,9 @@ const Logs: FC = () => {
             <>
               <LogFilters
                 search={search}
-                onSearchChange={(v) => {
-                  setSearch(v);
-                  setPage(0);
-                }}
+                onSearchChange={setSearch}
                 host={host}
-                onHostChange={(v) => {
-                  setHost(v);
-                  setPage(0);
-                }}
+                onHostChange={setHost}
                 status={status}
                 onStatusChange={(v) => {
                   setStatus(v);
@@ -132,15 +148,21 @@ const Logs: FC = () => {
                   setLevel(v);
                   setPage(0);
                 }}
-                sort={sort}
-                onSortChange={(v) => {
-                  setSort(v);
-                  setPage(0);
-                }}
                 onRefresh={refetchContent}
                 onDownload={handleDownload}
-                isLoading={isLoadingContent}
+                isLoading={isFetchingContent}
               />
+
+              {logData && logData.skipped_lines > 0 && (
+                <div
+                  className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm bg-yellow-50 text-yellow-800 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-200 dark:border-yellow-800"
+                  data-testid="skipped-lines-warning"
+                  role="status"
+                >
+                  <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
+                  {t('logs.skippedLines', { count: logData.skipped_lines })}
+                </div>
+              )}
 
               <Card className="overflow-hidden">
                 {isLoadingContent ? (
@@ -151,7 +173,14 @@ const Logs: FC = () => {
                   </div>
                 ) : (
                   <div data-testid="log-table">
-                    <LogTable logs={logData?.logs || []} isLoading={isLoadingContent} />
+                    <LogTable
+                      logs={logData?.logs || []}
+                      isLoading={isLoadingContent}
+                      isFetching={isFetchingContent}
+                      sortBy={sortBy}
+                      sortDir={sortDir}
+                      onSortChange={handleSortChange}
+                    />
                   </div>
                 )}
 
@@ -174,7 +203,7 @@ const Logs: FC = () => {
                           variant="secondary"
                           size="sm"
                           onClick={() => setPage((p) => Math.max(0, p - 1))}
-                          disabled={page === 0 || isLoadingContent}
+                          disabled={page === 0 || isFetchingContent}
                           data-testid="prev-page-button"
                           aria-label="Previous page"
                         >
@@ -184,7 +213,7 @@ const Logs: FC = () => {
                           variant="secondary"
                           size="sm"
                           onClick={() => setPage((p) => p + 1)}
-                          disabled={page >= totalPages - 1 || isLoadingContent}
+                          disabled={page >= totalPages - 1 || isFetchingContent}
                           data-testid="next-page-button"
                           aria-label="Next page"
                         >

--- a/frontend/src/pages/__tests__/Logs.test.tsx
+++ b/frontend/src/pages/__tests__/Logs.test.tsx
@@ -1,0 +1,191 @@
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import toast from 'react-hot-toast'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { getLogs, getLogContent, downloadLog, type LogFilter, type LogResponse } from '../../api/logs'
+import { renderWithQueryClient } from '../../test-utils/renderWithQueryClient'
+import Logs from '../Logs'
+
+vi.mock('../../api/logs', () => ({
+  getLogs: vi.fn(),
+  getLogContent: vi.fn(),
+  downloadLog: vi.fn(),
+}))
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+const mockFiles = [
+  { name: 'access.log', size: 1048576, mod_time: '2026-07-04T00:00:00Z' },
+  { name: 'error.log', size: 256000, mod_time: '2026-07-04T00:00:00Z' },
+]
+
+const entry = {
+  level: 'info',
+  ts: 1751630400,
+  logger: 'http.log.access',
+  msg: 'handled request',
+  request: {
+    remote_ip: '192.168.1.100',
+    method: 'GET',
+    host: 'api.example.com',
+    uri: '/api/v1/users',
+    proto: 'HTTP/2',
+  },
+  status: 200,
+  duration: 0.045,
+  size: 1234,
+}
+
+function mockContent(overrides: Partial<LogResponse> = {}) {
+  vi.mocked(getLogContent).mockImplementation((filename: string, filter: LogFilter = {}) =>
+    Promise.resolve({
+      filename,
+      logs: [entry],
+      total: 150,
+      limit: filter.limit ?? 50,
+      offset: filter.offset ?? 0,
+      skipped_lines: 0,
+      ...overrides,
+    })
+  )
+}
+
+function lastFilter(): LogFilter {
+  const calls = vi.mocked(getLogContent).mock.calls
+  return calls[calls.length - 1][1] as LogFilter
+}
+
+async function renderPage() {
+  renderWithQueryClient(<Logs />)
+  await waitFor(() => expect(getLogContent).toHaveBeenCalled())
+  await screen.findByTestId('log-table')
+}
+
+describe('Logs page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getLogs).mockResolvedValue(mockFiles)
+    vi.mocked(downloadLog).mockResolvedValue(undefined)
+    mockContent()
+  })
+
+  it('auto-selects the first log file and queries with default sort ts/desc', async () => {
+    await renderPage()
+
+    expect(vi.mocked(getLogContent).mock.calls[0][0]).toBe('access.log')
+    const filter = lastFilter()
+    expect(filter.sortBy).toBe('ts')
+    expect(filter.sort).toBe('desc')
+    expect(filter.offset).toBe(0)
+    expect(filter.limit).toBe(50)
+  })
+
+  it('toggles direction when the active Time column is clicked', async () => {
+    await renderPage()
+
+    fireEvent.click(screen.getByTestId('sort-header-ts'))
+    await waitFor(() => expect(lastFilter().sort).toBe('asc'))
+    expect(lastFilter().sortBy).toBe('ts')
+
+    fireEvent.click(screen.getByTestId('sort-header-ts'))
+    await waitFor(() => expect(lastFilter().sort).toBe('desc'))
+    expect(lastFilter().sortBy).toBe('ts')
+  })
+
+  it('activates a new column with descending direction', async () => {
+    await renderPage()
+
+    fireEvent.click(screen.getByTestId('sort-header-status'))
+
+    await waitFor(() => expect(lastFilter().sortBy).toBe('status'))
+    expect(lastFilter().sort).toBe('desc')
+  })
+
+  it('resets to the first page when the sort changes', async () => {
+    await renderPage()
+
+    fireEvent.click(screen.getByTestId('next-page-button'))
+    await waitFor(() => expect(lastFilter().offset).toBe(50))
+
+    fireEvent.click(screen.getByTestId('sort-header-uri'))
+    await waitFor(() => expect(lastFilter().sortBy).toBe('uri'))
+    expect(lastFilter().offset).toBe(0)
+  })
+
+  it('resets to the first page when switching log files', async () => {
+    await renderPage()
+
+    fireEvent.click(screen.getByTestId('next-page-button'))
+    await waitFor(() => expect(lastFilter().offset).toBe(50))
+
+    fireEvent.click(screen.getByTestId('log-file-error.log'))
+    await waitFor(() => expect(vi.mocked(getLogContent).mock.calls.at(-1)?.[0]).toBe('error.log'))
+    expect(lastFilter().offset).toBe(0)
+  })
+
+  it('debounces search input before querying and resets the page', async () => {
+    await renderPage()
+    const callsBefore = vi.mocked(getLogContent).mock.calls.length
+
+    fireEvent.change(screen.getByTestId('search-input'), { target: { value: 'users' } })
+
+    // No immediate query with the search term (debounced 300ms)
+    expect(vi.mocked(getLogContent).mock.calls.length).toBe(callsBefore)
+
+    await waitFor(() => expect(lastFilter().search).toBe('users'), { timeout: 2000 })
+    expect(lastFilter().offset).toBe(0)
+  })
+
+  it('downloads the selected log via the download button', async () => {
+    await renderPage()
+
+    fireEvent.click(screen.getByTestId('download-button'))
+
+    await waitFor(() => expect(downloadLog).toHaveBeenCalledWith('access.log'))
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('shows an error toast when the download fails and stays on the page', async () => {
+    vi.mocked(downloadLog).mockRejectedValue(new Error('Log file not found'))
+    await renderPage()
+
+    fireEvent.click(screen.getByTestId('download-button'))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to download log file'))
+    expect(screen.getByTestId('log-table')).toBeInTheDocument()
+  })
+
+  it('shows the skipped-lines warning when the backend reports skipped lines', async () => {
+    mockContent({ skipped_lines: 3 })
+    await renderPage()
+
+    expect(await screen.findByTestId('skipped-lines-warning')).toBeInTheDocument()
+  })
+
+  it('hides the skipped-lines warning when no lines were skipped', async () => {
+    await renderPage()
+
+    expect(screen.queryByTestId('skipped-lines-warning')).not.toBeInTheDocument()
+  })
+
+  it('shows the empty state when no logs match the filter', async () => {
+    mockContent({ logs: [], total: 0 })
+    await renderPage()
+
+    expect(await screen.findByText(/no logs found|no.*matching/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('page-info')).not.toBeInTheDocument()
+  })
+
+  it('renders pagination info for the current page', async () => {
+    await renderPage()
+
+    expect(screen.getByTestId('page-info')).toHaveTextContent('Showing 1 to 50 of 150 entries')
+    expect(screen.getByTestId('prev-page-button')).toBeDisabled()
+    expect(screen.getByTestId('next-page-button')).toBeEnabled()
+  })
+})

--- a/tests/tasks/logs-viewing.spec.ts
+++ b/tests/tasks/logs-viewing.spec.ts
@@ -10,6 +10,8 @@
  * - Log Content Display (2 tests): show columns, highlight error entries
  * - Pagination (3 tests): navigate pages, page info, button states
  * - Search/Filter (2 tests): text search, level filter
+ * - Sorting (7 tests, fixme until issue #686 lands): column header sorting,
+ *   aria-sort indication, page reset on sort change
  * - Download (2 tests): download file, error handling
  *
  * Route: /tasks/logs
@@ -172,6 +174,7 @@ async function setupLogMocks(
           total,
           limit,
           offset,
+          skipped_lines: 0,
         },
       });
     });
@@ -565,6 +568,189 @@ test.describe('Logs Page - WebKit Compatible Tests', () => {
 
       // Verify level parameter was sent
       expect(capturedLevel.toLowerCase()).toBe('error');
+    });
+  });
+
+  test.describe('Sorting', () => {
+    /**
+     * Sortable columns and their backend `sort_by` values (spec §5.4.4):
+     * Time→ts, Level→level, Status→status, Method→method, Path→uri.
+     * Each sortable header exposes a button with data-testid `sort-header-<field>`.
+     *
+     * All tests are marked test.fixme until the sorting feature (issue #686)
+     * is implemented in the backend and frontend; the fixme flags are removed
+     * in the final integration commit.
+     */
+
+    /** Latest sort-related query params captured by the mock route */
+    interface CapturedSortParams {
+      sortBy: string | null;
+      sortDir: string | null;
+      offset: number;
+    }
+
+    /**
+     * Mock the log endpoints and record the sorting/pagination query params
+     * of every content request into `captured` (same pattern as the
+     * pagination tests above).
+     */
+    async function setupSortCaptureMocks(
+      page: Page,
+      captured: CapturedSortParams,
+      entries = mockLogEntries,
+      totalCount?: number
+    ) {
+      await page.route('**/api/v1/logs', async (route) => {
+        await route.fulfill({ status: 200, json: mockLogFiles });
+      });
+
+      await page.route('**/api/v1/logs/access.log*', async (route) => {
+        const url = new URL(route.request().url());
+        captured.sortBy = url.searchParams.get('sort_by');
+        captured.sortDir = url.searchParams.get('sort');
+        captured.offset = parseInt(url.searchParams.get('offset') || '0');
+        const limit = parseInt(url.searchParams.get('limit') || '50');
+
+        await route.fulfill({
+          status: 200,
+          json: {
+            filename: 'access.log',
+            logs: entries.slice(captured.offset, captured.offset + limit),
+            total: totalCount ?? entries.length,
+            limit,
+            offset: captured.offset,
+            skipped_lines: 0,
+          },
+        });
+      });
+    }
+
+    /** Click a sort header and wait for the resulting content request */
+    async function clickSortHeader(page: Page, field: string) {
+      await Promise.all([
+        page.waitForResponse(
+          (resp) => resp.url().includes('/api/v1/logs/access.log') && resp.status() === 200
+        ),
+        page.getByTestId(`sort-header-${field}`).click(),
+      ]);
+    }
+
+    test.fixme('should sort by timestamp via Time header', async ({ page, authenticatedUser }) => {
+      await loginUser(page, authenticatedUser);
+
+      const captured: CapturedSortParams = { sortBy: null, sortDir: null, offset: 0 };
+      await setupSortCaptureMocks(page, captured);
+
+      const initialContentPromise = waitForAPIResponse(page, '/api/v1/logs/access.log', { status: 200 });
+      await page.goto('/tasks/logs', { waitUntil: 'domcontentloaded' });
+      await waitForLoadingComplete(page);
+      await initialContentPromise;
+
+      await test.step('Toggle the active Time column to ascending', async () => {
+        // Default sort is ts desc, so clicking the active Time header flips direction
+        await clickSortHeader(page, 'ts');
+        expect(captured.sortBy).toBe('ts');
+        expect(captured.sortDir).toBe('asc');
+      });
+
+      await test.step('Toggle the Time column back to descending', async () => {
+        await clickSortHeader(page, 'ts');
+        expect(captured.sortBy).toBe('ts');
+        expect(captured.sortDir).toBe('desc');
+      });
+    });
+
+    for (const field of ['status', 'level', 'method', 'uri'] as const) {
+      test.fixme(`should sort by ${field} via its column header`, async ({ page, authenticatedUser }) => {
+        await loginUser(page, authenticatedUser);
+
+        const captured: CapturedSortParams = { sortBy: null, sortDir: null, offset: 0 };
+        await setupSortCaptureMocks(page, captured);
+
+        const initialContentPromise = waitForAPIResponse(page, '/api/v1/logs/access.log', { status: 200 });
+        await page.goto('/tasks/logs', { waitUntil: 'domcontentloaded' });
+        await waitForLoadingComplete(page);
+        await initialContentPromise;
+
+        await test.step(`Sort by the ${field} column`, async () => {
+          await clickSortHeader(page, field);
+
+          // A newly activated column starts in descending order (spec R7)
+          expect(captured.sortBy).toBe(field);
+          expect(captured.sortDir).toBe('desc');
+        });
+      });
+    }
+
+    test.fixme('should indicate active sort with aria-sort', async ({ page, authenticatedUser }) => {
+      await loginUser(page, authenticatedUser);
+
+      const captured: CapturedSortParams = { sortBy: null, sortDir: null, offset: 0 };
+      await setupSortCaptureMocks(page, captured);
+
+      const initialContentPromise = waitForAPIResponse(page, '/api/v1/logs/access.log', { status: 200 });
+      await page.goto('/tasks/logs', { waitUntil: 'domcontentloaded' });
+      await waitForLoadingComplete(page);
+      await initialContentPromise;
+
+      const timeHeader = page.getByRole('columnheader', { name: /time/i });
+      const statusHeader = page.getByRole('columnheader', { name: /status/i });
+
+      await test.step('Verify sortable header structure is accessible', async () => {
+        // Accessible names must stay Time/Level/Status/Method (spec §5.4.4)
+        await expect(page.getByTestId('log-table')).toMatchAriaSnapshot(`
+          - table:
+            - rowgroup:
+              - row:
+                - columnheader "Time"
+                - columnheader "Level"
+                - columnheader "Status"
+                - columnheader "Method"
+        `);
+      });
+
+      await test.step('Default sort is Time descending', async () => {
+        await expect(timeHeader).toHaveAttribute('aria-sort', 'descending');
+      });
+
+      await test.step('Clicking the active Time header flips aria-sort to ascending', async () => {
+        await clickSortHeader(page, 'ts');
+        await expect(timeHeader).toHaveAttribute('aria-sort', 'ascending');
+      });
+
+      await test.step('Activating the Status column moves the aria-sort indicator', async () => {
+        await clickSortHeader(page, 'status');
+        await expect(statusHeader).toHaveAttribute('aria-sort', 'descending');
+        await expect(timeHeader).not.toHaveAttribute('aria-sort', /ascending|descending/);
+      });
+    });
+
+    test.fixme('should reset to first page when sorting changes', async ({ page, authenticatedUser }) => {
+      await loginUser(page, authenticatedUser);
+
+      const captured: CapturedSortParams = { sortBy: null, sortDir: null, offset: 0 };
+      await setupSortCaptureMocks(page, captured, generateMockEntries(150), 150);
+
+      const initialContentPromise = waitForAPIResponse(page, '/api/v1/logs/access.log', { status: 200 });
+      await page.goto('/tasks/logs', { waitUntil: 'domcontentloaded' });
+      await waitForLoadingComplete(page);
+      await initialContentPromise;
+
+      await test.step('Navigate to the second page', async () => {
+        await Promise.all([
+          page.waitForResponse(
+            (resp) => resp.url().includes('/api/v1/logs/access.log') && resp.status() === 200
+          ),
+          getNextButton(page).click(),
+        ]);
+        expect(captured.offset).toBe(50);
+      });
+
+      await test.step('Sorting by a column resets to the first page', async () => {
+        await clickSortHeader(page, 'status');
+        expect(captured.sortBy).toBe('status');
+        expect(captured.offset).toBe(0);
+      });
     });
   });
 

--- a/tests/tasks/logs-viewing.spec.ts
+++ b/tests/tasks/logs-viewing.spec.ts
@@ -10,7 +10,7 @@
  * - Log Content Display (2 tests): show columns, highlight error entries
  * - Pagination (3 tests): navigate pages, page info, button states
  * - Search/Filter (2 tests): text search, level filter
- * - Sorting (7 tests, fixme until issue #686 lands): column header sorting,
+ * - Sorting (7 tests): column header sorting,
  *   aria-sort indication, page reset on sort change
  * - Download (2 tests): download file, error handling
  *
@@ -576,10 +576,6 @@ test.describe('Logs Page - WebKit Compatible Tests', () => {
      * Sortable columns and their backend `sort_by` values (spec §5.4.4):
      * Time→ts, Level→level, Status→status, Method→method, Path→uri.
      * Each sortable header exposes a button with data-testid `sort-header-<field>`.
-     *
-     * All tests are marked test.fixme until the sorting feature (issue #686)
-     * is implemented in the backend and frontend; the fixme flags are removed
-     * in the final integration commit.
      */
 
     /** Latest sort-related query params captured by the mock route */
@@ -635,7 +631,7 @@ test.describe('Logs Page - WebKit Compatible Tests', () => {
       ]);
     }
 
-    test.fixme('should sort by timestamp via Time header', async ({ page, authenticatedUser }) => {
+    test('should sort by timestamp via Time header', async ({ page, authenticatedUser }) => {
       await loginUser(page, authenticatedUser);
 
       const captured: CapturedSortParams = { sortBy: null, sortDir: null, offset: 0 };
@@ -654,14 +650,19 @@ test.describe('Logs Page - WebKit Compatible Tests', () => {
       });
 
       await test.step('Toggle the Time column back to descending', async () => {
-        await clickSortHeader(page, 'ts');
-        expect(captured.sortBy).toBe('ts');
-        expect(captured.sortDir).toBe('desc');
+        // The ts/desc page was fetched on initial load and is still fresh in
+        // the React Query cache (30s staleTime), so toggling back is served
+        // from cache without a network request — assert the UI state instead.
+        await page.getByTestId('sort-header-ts').click();
+        await expect(page.getByRole('columnheader', { name: /time/i })).toHaveAttribute(
+          'aria-sort',
+          'descending'
+        );
       });
     });
 
     for (const field of ['status', 'level', 'method', 'uri'] as const) {
-      test.fixme(`should sort by ${field} via its column header`, async ({ page, authenticatedUser }) => {
+      test(`should sort by ${field} via its column header`, async ({ page, authenticatedUser }) => {
         await loginUser(page, authenticatedUser);
 
         const captured: CapturedSortParams = { sortBy: null, sortDir: null, offset: 0 };
@@ -682,7 +683,7 @@ test.describe('Logs Page - WebKit Compatible Tests', () => {
       });
     }
 
-    test.fixme('should indicate active sort with aria-sort', async ({ page, authenticatedUser }) => {
+    test('should indicate active sort with aria-sort', async ({ page, authenticatedUser }) => {
       await loginUser(page, authenticatedUser);
 
       const captured: CapturedSortParams = { sortBy: null, sortDir: null, offset: 0 };
@@ -725,7 +726,7 @@ test.describe('Logs Page - WebKit Compatible Tests', () => {
       });
     });
 
-    test.fixme('should reset to first page when sorting changes', async ({ page, authenticatedUser }) => {
+    test('should reset to first page when sorting changes', async ({ page, authenticatedUser }) => {
       await loginUser(page, authenticatedUser);
 
       const captured: CapturedSortParams = { sortBy: null, sortDir: null, offset: 0 };


### PR DESCRIPTION
Closes #686

## Summary

Completes the System Log Viewer on **Tasks → Logs**: column sorting end-to-end (the one genuinely missing feature), security hardening of the log read/download paths, robustness for corrupted/oversized lines, and a hooks/i18n refactor — delivered as one feature PR with ordered commits per the plan in `docs/plans/current_spec.md`.

### Stale-issue findings

Research showed the issue text was partially stale: pagination, filtering (search/level/host/status), and download already existed end-to-end, and the E2E skip flags referenced in the issue were already removed (commit `d29b8e9c`). The real scope delivered here: **column sorting**, **download/path-resolution hardening**, **corrupted-line handling**, and CLAUDE.md-pattern refactors (React Query hooks, i18n, `ShouldBindQuery`).

## What changed

**Backend**
- `GET /api/v1/logs/:filename` gains `sort_by` (`ts|level|method|uri|status`, default `ts`; invalid → 400) alongside existing `sort=asc|desc`; response gains additive `skipped_lines` field.
- Log reader rewritten as a `ReadSlice` loop with a 1MB per-line cap and no over-cap accumulation; precise corruption criterion (over-cap OR (JSON-parse failure AND (invalid UTF-8 OR NUL bytes))) — damaged lines are skipped and counted instead of 500ing the whole query.
- Download/path hardening: `ErrInvalidFilename` sentinel with `errors.Is` mapping, allowlist built from raw log-directory entries (symlink aliases like `charon.log`/`cpmp.log` stay servable), `GetLogPath` returns the `EvalSymlinks`-resolved path that callers open (TOCTOU closed), both-sides symlink containment (no-relaxation invariant), regular-file check, quoted `Content-Disposition` via `c.FileAttachment` + explicit `text/plain`.

**Frontend**
- Clickable sortable column headers (`aria-sort`, accessible names preserved), new Level column, `skipped-lines-warning` banner; the sort dropdown is replaced by header clicks (approved UX change).
- New `useLogs` / `useDebouncedValue` hooks (TanStack Query, `keepPreviousData`); blob-based `downloadLog` through `client.ts` with toast error handling (no more raw `window.location.href`); `encodeURIComponent` on filenames; i18n for hardcoded strings across 5 locales.

**Docs**: `docs/features.md` + `docs/features/logs.md` updated for novice users.

### Behavior notes (test-pinned)

- Default ordering is now a true `ts`-desc sort instead of file-order reversal: plain-text lines without parseable timestamps sort **last** under desc (previously first).
- `limit=abc` → 400 (was silently ignored); `limit=0` → default 50. Neither reachable from the shipped UI.

## Security: `#nosec G304` / `nosemgrep` re-justification (spec §5.7)

`#nosec G304` (+ `//nolint:gosec`, `nosemgrep` gin-path-traversal-taint) at the `QueryLogs` and `Download` file opens are retained and re-justified: the opened path is no longer merely prefix-checked — it is the **symlink-resolved** path returned by `GetLogPath`, which enforces (1) `filepath.Base` equality with explicit rejection of `""`/`"."`/`".."` and literal percent-encoded separators, (2) an allowlist built from raw log-directory entries (unknown names are refused without opening any file), (3) prefix containment in a cleaned log dir, and (4) both-sides `EvalSymlinks` containment: the resolved file must be a regular file inside a resolved log directory. Because callers open exactly the resolved path, no client-influenced symlink component exists between validation and open. The taint findings are false positives by construction.

## E2E evidence

`npx playwright test tests/tasks/logs-viewing.spec.ts --project=firefox` → **25/25 passed, 0 flakes/retries** (18 pre-existing + 7 new sorting tests; zero skip/fixme flags remain).

| New test | Verifies |
|---|---|
| sort by timestamp via Time header | `sort_by=ts`, `sort` toggles desc→asc→desc |
| sort by status/level/method/uri headers | `sort_by=<field>`, `sort=desc` on first click |
| aria-sort indication | `aria-sort` on active column only, moves on column switch |
| reset to first page on sort change | `offset=0` after sorting from page 2 |

**>1MB robustness (acceptance criterion 4):** 2.1MB fixture (7,500 JSON lines + one 1.2MB unterminated line + 2KB binary garbage) → all queries HTTP 200 in 27–45ms, `skipped_lines=10`, correct totals, no 500s.

## Validation

- Backend coverage 89.0% line / frontend 88.7% stmt (gate 85%); patch coverage **95.8%** (gate 90%)
- GORM security scan: 0 CRITICAL/HIGH · Semgrep (275 rules): 0 findings · Trivy: 0 vulns in lockfiles
- Local CodeQL CLI unavailable — **CI CodeQL on this PR is the gate**
- `go build ./...`, `npm run build`, `npm run type-check`, lefthook: all clean

## Rollback

Single-PR revert restores current behavior entirely; no DB migrations.
