### PR TITLE
fix(ci): pin release-please target-branch to main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: main


### PR DESCRIPTION
## Summary
- `release-please.yml` failed on push to `main`: "Missing required manifest config: release-please-config.json" (run: https://github.com/Wikid82/Charon/actions/runs/32064583504)
- Root cause: `googleapis/release-please-action` defaults its `target-branch` input to the **repository's default branch** (via the GitHub API), not the branch that triggered the workflow. This repo's default branch is `development`, but `release-please-config.json`/`.release-please-manifest.json` only exist on `main` (added by #1256, deliberately scoped to `main` only, bypassing the normal `development`-first flow). The action was looking at `development`'s tree and finding nothing there.
- Fix: explicitly set `target-branch: main` on the action step, so it always operates against `main` regardless of the repo's default-branch setting.

## Test plan
- YAML validated locally.
- `lefthook run pre-commit` passed (actionlint, semgrep, etc.).
- Live verification: re-running `release-please.yml` on `main` after this merges should succeed and open the initial release PR — this is the only way to confirm the fix, since it depends on GitHub's actual default-branch resolution behavior.