### PR TITLE
chore(ci): add timeout and retry to Playwright browser installs

### DIFF
--- a/.github/workflows/e2e-tests-split.yml
+++ b/.github/workflows/e2e-tests-split.yml
@@ -324,17 +324,19 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 15
-          retry_on: error
-          warning_on_retry: true
-          command: |
-            set -euo pipefail
-            echo "📦 Installing Chromium..."
-            npx playwright install --with-deps chromium
+        run: |
+          set -uo pipefail
+          echo "📦 Installing Chromium..."
+          for attempt in 1 2 3; do
+            timeout 10m npx playwright install --with-deps chromium && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              sleep 15
+            else
+              echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Run Chromium Security Enforcement Tests
         run: |
@@ -564,30 +566,34 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 15
-          retry_on: error
-          warning_on_retry: true
-          command: |
-            set -euo pipefail
-            echo "📦 Installing Chromium (required by security-tests dependency)..."
-            npx playwright install --with-deps chromium
+        run: |
+          set -uo pipefail
+          echo "📦 Installing Chromium (required by security-tests dependency)..."
+          for attempt in 1 2 3; do
+            timeout 10m npx playwright install --with-deps chromium && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              sleep 15
+            else
+              echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Install Playwright Firefox
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 15
-          retry_on: error
-          warning_on_retry: true
-          command: |
-            set -euo pipefail
-            echo "📦 Installing Firefox..."
-            npx playwright install --with-deps firefox
+        run: |
+          set -uo pipefail
+          echo "📦 Installing Firefox..."
+          for attempt in 1 2 3; do
+            timeout 10m npx playwright install --with-deps firefox && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              sleep 15
+            else
+              echo "ERROR: Playwright firefox install failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Run Firefox Security Enforcement Tests
         run: |
@@ -820,30 +826,34 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 15
-          retry_on: error
-          warning_on_retry: true
-          command: |
-            set -euo pipefail
-            echo "📦 Installing Chromium (required by security-tests dependency)..."
-            npx playwright install --with-deps chromium
+        run: |
+          set -uo pipefail
+          echo "📦 Installing Chromium (required by security-tests dependency)..."
+          for attempt in 1 2 3; do
+            timeout 10m npx playwright install --with-deps chromium && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              sleep 15
+            else
+              echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Install Playwright WebKit
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 15
-          retry_on: error
-          warning_on_retry: true
-          command: |
-            set -euo pipefail
-            echo "📦 Installing WebKit..."
-            npx playwright install --with-deps webkit
+        run: |
+          set -uo pipefail
+          echo "📦 Installing WebKit..."
+          for attempt in 1 2 3; do
+            timeout 10m npx playwright install --with-deps webkit && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              sleep 15
+            else
+              echo "ERROR: Playwright webkit install failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Run WebKit Security Enforcement Tests
         run: |
@@ -1103,17 +1113,19 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 15
-          retry_on: error
-          warning_on_retry: true
-          command: |
-            set -euo pipefail
-            echo "📦 Installing Chromium..."
-            npx playwright install --with-deps chromium
+        run: |
+          set -uo pipefail
+          echo "📦 Installing Chromium..."
+          for attempt in 1 2 3; do
+            timeout 10m npx playwright install --with-deps chromium && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              sleep 15
+            else
+              echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Run Chromium Non-Security Tests (Shard ${{ matrix.shard }}/${{ matrix.total-shards }})
         run: |
@@ -1346,30 +1358,34 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 15
-          retry_on: error
-          warning_on_retry: true
-          command: |
-            set -euo pipefail
-            echo "📦 Installing Chromium (required by security-tests dependency)..."
-            npx playwright install --with-deps chromium
+        run: |
+          set -uo pipefail
+          echo "📦 Installing Chromium (required by security-tests dependency)..."
+          for attempt in 1 2 3; do
+            timeout 10m npx playwright install --with-deps chromium && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              sleep 15
+            else
+              echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Install Playwright Firefox
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 15
-          retry_on: error
-          warning_on_retry: true
-          command: |
-            set -euo pipefail
-            echo "📦 Installing Firefox..."
-            npx playwright install --with-deps firefox
+        run: |
+          set -uo pipefail
+          echo "📦 Installing Firefox..."
+          for attempt in 1 2 3; do
+            timeout 10m npx playwright install --with-deps firefox && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              sleep 15
+            else
+              echo "ERROR: Playwright firefox install failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Run Firefox Non-Security Tests (Shard ${{ matrix.shard }}/${{ matrix.total-shards }})
         run: |
@@ -1602,30 +1618,34 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 15
-          retry_on: error
-          warning_on_retry: true
-          command: |
-            set -euo pipefail
-            echo "📦 Installing Chromium (required by security-tests dependency)..."
-            npx playwright install --with-deps chromium
+        run: |
+          set -uo pipefail
+          echo "📦 Installing Chromium (required by security-tests dependency)..."
+          for attempt in 1 2 3; do
+            timeout 10m npx playwright install --with-deps chromium && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              sleep 15
+            else
+              echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Install Playwright WebKit
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 15
-          retry_on: error
-          warning_on_retry: true
-          command: |
-            set -euo pipefail
-            echo "📦 Installing WebKit..."
-            npx playwright install --with-deps webkit
+        run: |
+          set -uo pipefail
+          echo "📦 Installing WebKit..."
+          for attempt in 1 2 3; do
+            timeout 10m npx playwright install --with-deps webkit && break
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              sleep 15
+            else
+              echo "ERROR: Playwright webkit install failed after 3 attempts" >&2
+              exit 1
+            fi
+          done
 
       - name: Run WebKit Non-Security Tests (Shard ${{ matrix.shard }}/${{ matrix.total-shards }})
         run: |

--- a/.github/workflows/e2e-tests-split.yml
+++ b/.github/workflows/e2e-tests-split.yml
@@ -324,12 +324,17 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium
-        run: |
-          echo "📦 Installing Chromium..."
-          npx playwright install --with-deps chromium
-          EXIT_CODE=$?
-          echo "✅ Install command completed (exit code: $EXIT_CODE)"
-          exit "$EXIT_CODE"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          retry_on: error
+          warning_on_retry: true
+          command: |
+            set -euo pipefail
+            echo "📦 Installing Chromium..."
+            npx playwright install --with-deps chromium
 
       - name: Run Chromium Security Enforcement Tests
         run: |
@@ -559,20 +564,30 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
-        run: |
-          echo "📦 Installing Chromium (required by security-tests dependency)..."
-          npx playwright install --with-deps chromium
-          EXIT_CODE=$?
-          echo "✅ Install command completed (exit code: $EXIT_CODE)"
-          exit "$EXIT_CODE"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          retry_on: error
+          warning_on_retry: true
+          command: |
+            set -euo pipefail
+            echo "📦 Installing Chromium (required by security-tests dependency)..."
+            npx playwright install --with-deps chromium
 
       - name: Install Playwright Firefox
-        run: |
-          echo "📦 Installing Firefox..."
-          npx playwright install --with-deps firefox
-          EXIT_CODE=$?
-          echo "✅ Install command completed (exit code: $EXIT_CODE)"
-          exit "$EXIT_CODE"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          retry_on: error
+          warning_on_retry: true
+          command: |
+            set -euo pipefail
+            echo "📦 Installing Firefox..."
+            npx playwright install --with-deps firefox
 
       - name: Run Firefox Security Enforcement Tests
         run: |
@@ -805,20 +820,30 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
-        run: |
-          echo "📦 Installing Chromium (required by security-tests dependency)..."
-          npx playwright install --with-deps chromium
-          EXIT_CODE=$?
-          echo "✅ Install command completed (exit code: $EXIT_CODE)"
-          exit "$EXIT_CODE"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          retry_on: error
+          warning_on_retry: true
+          command: |
+            set -euo pipefail
+            echo "📦 Installing Chromium (required by security-tests dependency)..."
+            npx playwright install --with-deps chromium
 
       - name: Install Playwright WebKit
-        run: |
-          echo "📦 Installing WebKit..."
-          npx playwright install --with-deps webkit
-          EXIT_CODE=$?
-          echo "✅ Install command completed (exit code: $EXIT_CODE)"
-          exit "$EXIT_CODE"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          retry_on: error
+          warning_on_retry: true
+          command: |
+            set -euo pipefail
+            echo "📦 Installing WebKit..."
+            npx playwright install --with-deps webkit
 
       - name: Run WebKit Security Enforcement Tests
         run: |
@@ -1078,12 +1103,17 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium
-        run: |
-          echo "📦 Installing Chromium..."
-          npx playwright install --with-deps chromium
-          EXIT_CODE=$?
-          echo "✅ Install command completed (exit code: $EXIT_CODE)"
-          exit "$EXIT_CODE"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          retry_on: error
+          warning_on_retry: true
+          command: |
+            set -euo pipefail
+            echo "📦 Installing Chromium..."
+            npx playwright install --with-deps chromium
 
       - name: Run Chromium Non-Security Tests (Shard ${{ matrix.shard }}/${{ matrix.total-shards }})
         run: |
@@ -1316,20 +1346,30 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
-        run: |
-          echo "📦 Installing Chromium (required by security-tests dependency)..."
-          npx playwright install --with-deps chromium
-          EXIT_CODE=$?
-          echo "✅ Install command completed (exit code: $EXIT_CODE)"
-          exit "$EXIT_CODE"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          retry_on: error
+          warning_on_retry: true
+          command: |
+            set -euo pipefail
+            echo "📦 Installing Chromium (required by security-tests dependency)..."
+            npx playwright install --with-deps chromium
 
       - name: Install Playwright Firefox
-        run: |
-          echo "📦 Installing Firefox..."
-          npx playwright install --with-deps firefox
-          EXIT_CODE=$?
-          echo "✅ Install command completed (exit code: $EXIT_CODE)"
-          exit "$EXIT_CODE"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          retry_on: error
+          warning_on_retry: true
+          command: |
+            set -euo pipefail
+            echo "📦 Installing Firefox..."
+            npx playwright install --with-deps firefox
 
       - name: Run Firefox Non-Security Tests (Shard ${{ matrix.shard }}/${{ matrix.total-shards }})
         run: |
@@ -1562,20 +1602,30 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium (required by security-tests dependency)
-        run: |
-          echo "📦 Installing Chromium (required by security-tests dependency)..."
-          npx playwright install --with-deps chromium
-          EXIT_CODE=$?
-          echo "✅ Install command completed (exit code: $EXIT_CODE)"
-          exit "$EXIT_CODE"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          retry_on: error
+          warning_on_retry: true
+          command: |
+            set -euo pipefail
+            echo "📦 Installing Chromium (required by security-tests dependency)..."
+            npx playwright install --with-deps chromium
 
       - name: Install Playwright WebKit
-        run: |
-          echo "📦 Installing WebKit..."
-          npx playwright install --with-deps webkit
-          EXIT_CODE=$?
-          echo "✅ Install command completed (exit code: $EXIT_CODE)"
-          exit "$EXIT_CODE"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          retry_on: error
+          warning_on_retry: true
+          command: |
+            set -euo pipefail
+            echo "📦 Installing WebKit..."
+            npx playwright install --with-deps webkit
 
       - name: Run WebKit Non-Security Tests (Shard ${{ matrix.shard }}/${{ matrix.total-shards }})
         run: |

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -24,18 +24,26 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       className,
       type,
       disabled,
+      id,
       ...props
     },
     ref
   ) => {
     const [showPassword, setShowPassword] = React.useState(false)
     const isPassword = type === 'password'
+    // Auto-generate a stable id when the caller doesn't supply one, so the
+    // label is always programmatically associated with its control (WCAG
+    // 1.3.1 / 3.3.2). `id` is destructured out explicitly above — not left
+    // inside `...props` — so this fallback can't be silently overridden by
+    // a stray `id: undefined` reaching the spread below in prop order.
+    const generatedId = React.useId()
+    const inputId = id ?? generatedId
 
     return (
       <div className="w-full">
         {label && (
           <label
-            htmlFor={props.id}
+            htmlFor={inputId}
             className="block text-sm font-medium text-content-secondary mb-1.5"
           >
             {label}
@@ -49,6 +57,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           )}
           <input
             ref={ref}
+            id={inputId}
             type={isPassword ? (showPassword ? 'text' : 'password') : type}
             disabled={disabled}
             aria-describedby={error && errorTestId ? errorTestId : undefined}

--- a/frontend/src/components/ui/__tests__/Input.test.tsx
+++ b/frontend/src/components/ui/__tests__/Input.test.tsx
@@ -24,6 +24,21 @@ describe('Input', () => {
     expect(label).toHaveAttribute('for', 'email-input')
   })
 
+  it('associates label with input via auto-generated id when no id is passed', () => {
+    render(<Input label="Email" />)
+
+    const input = screen.getByLabelText('Email')
+    expect(input).toBeInTheDocument()
+    expect(input.tagName).toBe('INPUT')
+  })
+
+  it('uses the explicit id when provided, not the generated one', () => {
+    render(<Input label="Email" id="custom-email-id" />)
+
+    const input = screen.getByLabelText('Email')
+    expect(input).toHaveAttribute('id', 'custom-email-id')
+  })
+
   it('renders with error state and message', () => {
     render(
       <Input

--- a/tests/utils/wait-helpers.ts
+++ b/tests/utils/wait-helpers.ts
@@ -1330,7 +1330,18 @@ export async function gotoTolerant(
 ): Promise<void> {
   const { timeout = 15000 } = options;
 
-  await page.goto(url, { waitUntil: 'commit', timeout }).catch((error: unknown) => {
+  // waitUntil: 'domcontentloaded', NOT 'commit' — see commit 7503c01a and
+  // docs/reports/qa_report_2026-07-26_shard4-reload-hang.md. 'commit' fires
+  // on Firefox's earliest possible navigation signal, which this repo's own
+  // trace evidence (docs/plans/current_spec.md, PR #1259 RCA) shows Firefox
+  // can fail to emit at all for some goto()/reload() calls, leaving
+  // Playwright's frame-navigation tracker stuck and blocking every
+  // subsequent locator-based wait on the page for a second full timeout.
+  // 'domcontentloaded' is the value already used by 100+ other call sites
+  // in this suite (including tests/settings/navigation-settle-regression.spec.ts,
+  // which codifies this exact failure shape) and is the value this helper's
+  // predecessor code used before it was silently dropped during extraction.
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout }).catch((error: unknown) => {
     if (!isExpectedNavigationRace(error)) {
       throw error;
     }
@@ -1355,7 +1366,9 @@ export async function reloadTolerant(
 ): Promise<void> {
   const { timeout = 15000 } = options;
 
-  await page.reload({ waitUntil: 'commit', timeout }).catch((error: unknown) => {
+  // See gotoTolerant's comment above — same 'commit' → 'domcontentloaded'
+  // fix, for the same reason.
+  await page.reload({ waitUntil: 'domcontentloaded', timeout }).catch((error: unknown) => {
     if (!isExpectedNavigationRace(error)) {
       throw error;
     }


### PR DESCRIPTION
## Summary
- `apt-get` inside `npx playwright install --with-deps <browser>` can silently hang against a flaky Azure apt mirror with no timeout of its own, burning the job's full 60-minute `timeout-minutes` and surfacing as a misleading `cancelled` run instead of a clear, actionable failure (observed on run [32068948141](https://github.com/Wikid82/Charon/actions/runs/32068948141/job/95565500260) — `E2E Chromium (Security Enforcement)`, triggered on release-please's PR #1258 against `main`).
- Wraps all 10 Playwright browser install steps in `e2e-tests-split.yml` with a bash `timeout`-based retry loop (10 min/attempt, 3 attempts, 15s backoff) — an earlier attempt used `nick-fields/retry`, but that action crashes with `Error: kill EPERM` when it tries to kill a process tree that `playwright install --with-deps` has partially elevated to root via sudo, so it never actually retried. The bash `timeout` command signals its own direct child and avoids that cross-UID kill problem entirely.
- Job-level `timeout-minutes: 60` and the `concurrency: cancel-in-progress: true` block are left untouched — those are correct as-is.
- Fixes a real, systemic accessibility defect in `frontend/src/components/ui/Input.tsx`: its `<label htmlFor>` was never programmatically associated with its `<input>` unless the caller passed an explicit `id` — 115 of 118 call sites app-wide never do. `Input.tsx` now auto-generates a stable id via `React.useId()` when one isn't supplied. Note: generated ids contain colons (e.g. `:r0:`), so a naive `page.locator('#' + id)` against one of these auto-generated ids won't work as a raw CSS selector — no current call site does this, but worth knowing.
- Fixes the actual root cause of the "E2E Firefox (Shard 4/4)" CI failure on `tests/settings/user-lifecycle.spec.ts` (this is the **seventh** fix attempt at this exact test's Firefox flakiness — see commit message for full trace-level RCA): a 2026-07-28 refactor (`7503c01a`) silently downgraded `gotoTolerant`/`reloadTolerant` (`tests/utils/wait-helpers.ts`) from `waitUntil: 'domcontentloaded'` to `waitUntil: 'commit'`. Firefox can fail to emit a trackable `commit` event at all, which leaves Playwright's frame-navigation tracker believing a navigation is still pending — so the *next* locator-based assertion blocks for a second full timeout without ever querying the DOM, even though the page had already rendered correctly. Restored to `domcontentloaded`, the value proven correct by the original RCA two days earlier and already used by 100+ other call sites in this suite.

## Test plan
- [x] YAML validated, `actionlint` clean, `lefthook run pre-commit` passes (incl. semgrep, 0 findings)
- [x] `e2e-tests-split.yml` has an unfiltered `pull_request:` trigger, so this PR runs the full "E2E Tests" workflow directly
- [x] `Input.tsx`: 2 new unit tests (label associates via auto-id; explicit id still respected), all 18 existing `Input.test.tsx` cases pass, `npm run type-check` clean, `npm run build` clean
- [x] `wait-helpers.ts`: existing 30-case real-browser `wait-helpers.spec.ts` suite passes unmodified under Firefox
- [x] `tests/settings/user-lifecycle.spec.ts --project=firefox --repeat-each=3` — 3/3 clean passes, zero flakes (was 3/3 failures before)
- [x] `tests/settings/navigation-settle-regression.spec.ts --project=firefox` — passes
- [x] Blast-radius check: `tests/settings/user-management.spec.ts` (full file, 32 passed/1 pre-existing skip) and `tests/tasks/long-running-operations.spec.ts` (grep-scoped) — both pass, zero regressions
- [x] Frontend coverage gate: `scripts/frontend-test-coverage.sh` → PASS (90.81% lines vs 87% minimum)
- [x] `scripts/local-patch-report.sh` → 100% patch coverage, all scopes pass
- [x] `cd backend && go build ./...` clean (unaffected, gated per DoD anyway)