### PR TITLE
chore(ci): defense-in-depth hardening against silent workflow_run trigger failures

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,6 +35,16 @@ on:
     # See GH #1235 / docs/plans/current_spec.md for the full rationale.
     branches: [main, development]
   workflow_dispatch:
+  # Reviewed as part of a default-branch/workflow_run reliability pass. This
+  # link is dormant in normal operation: docker-lint.yml's only trigger is
+  # workflow_dispatch, so nothing in the repo's day-to-day flow ever causes
+  # Docker Lint to run and chain into this workflow. Left unchanged
+  # deliberately -- this workflow's real, CI-critical triggers are the
+  # direct push/pull_request above, which never route through workflow_run
+  # and are therefore categorically unaffected by that bug class. Making
+  # Docker Lint auto-trigger would be a functional scope change (hadolint
+  # running on every push/PR), not a trigger-reliability fix, so it's out
+  # of scope here.
   workflow_run:
     workflows: ["Docker Lint"]
     types: [completed]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["Docker Build, Publish & Test"]
     types: [completed]
+    branches: [main]
   workflow_dispatch:   # Allow manual trigger
 
 # Sets permissions to allow deployment to GitHub Pages

--- a/.github/workflows/history-rewrite-tests.yml
+++ b/.github/workflows/history-rewrite-tests.yml
@@ -4,6 +4,16 @@ on:
   workflow_run:
     workflows: ["Docker Build, Publish & Test"]
     types: [completed]
+  pull_request:
+    paths:
+      - 'scripts/history-rewrite/**'
+      - '.github/workflows/history-rewrite-tests.yml'
+  push:
+    branches: [main, development]
+    paths:
+      - 'scripts/history-rewrite/**'
+      - '.github/workflows/history-rewrite-tests.yml'
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
@@ -15,7 +25,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout with full history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/propagate-changes.yml
+++ b/.github/workflows/propagate-changes.yml
@@ -5,6 +5,19 @@ on:
     workflows: ["Docker Build, Publish & Test"]
     types: [completed]
     branches: [ main, development ]
+  # NOTE for future contributors: do not add a direct `push:` trigger here as
+  # a workflow_run-reliability fallback without ALSO updating the job-level
+  # `if:` below. The CURRENT_BRANCH/CURRENT_SHA env fallbacks (`|| github.ref_name`
+  # / `|| github.sha`) already resolve correctly on a `push` event, but the
+  # `if:` only recognizes `workflow_dispatch` or a matching `workflow_run` —
+  # it has no `github.event_name == 'push'` clause, so a bare `push:` addition
+  # would silently no-op the job on every push (worse than today: it would
+  # show as a registered trigger in the Actions UI while never actually
+  # running). workflow_run is also semantically correct here regardless: this
+  # job should only propagate a commit Docker Build has already validated as
+  # successful, which a raw `push` event can't guarantee. The existing
+  # `workflow_dispatch: {}` below (added in 5245858a) is the intended manual
+  # fallback if workflow_run ever silently fails to fire again.
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
## Root cause (already fixed, not part of this diff)

GitHub's `workflow_run` trigger is unreliable for upstream workflow completions on a branch other than the repo's GitHub-configured **default branch**. This repo's default branch was `development` while `main` is the actual release branch — proven empirically: a push to `main` that completed "Docker Build, Publish & Test" successfully triggered **zero** `workflow_run`-gated workflows in the following ~20 minutes, while a separate completion on `development` ~10 minutes later triggered **eight** simultaneously.

The default branch has already been flipped to `main` via the GitHub API (confirmed: `gh api repos/Wikid82/Charon -q '.default_branch'` → `main`). No branch protection rules exist on either branch.

## This PR: defense-in-depth, judged file-by-file

Now that the root cause is fixed, should any of the 8 `workflow_run`-dependent workflows also gain a redundant fallback trigger so this class of bug (silently not firing, no visible failure mode) can't recur if the default branch setting ever drifts again? A blanket "add `push:` everywhere" is wrong — for several of these a redundant trigger would be net-negative (duplicate runs, races, duplicate side effects like double-created GitHub issues).

| File | Decision | Why |
|---|---|---|
| `propagate-changes.yml` | **No change** (comment only) | `workflow_run` is semantically correct — must wait for a *validated* build. Traced the `CURRENT_BRANCH`/`CURRENT_SHA` fallbacks: they'd resolve correctly on a `push` event, but the job-level `if:` has no `push` clause, so adding `push:` alone would silently skip the job every time — documented as a landmine, not silently "fixed." |
| `docs.yml` | **Added `branches: [main]`** to `workflow_run` | No behavior change to `deploy` (already `main`-gated) — just stops the `build` job running for completions on branches that could never reach `deploy`. A `push` trigger was rejected: the concurrency group is keyed by `event_name`, so `push` and `workflow_run` wouldn't cancel each other, risking two Pages deploys for one commit. |
| `docs-to-issues.yml` | **No change** | Mutates state (creates GitHub issues) with no idempotency guard beyond a post-hoc file move — a redundant trigger risks duplicate issues. |
| `dry-run-history-rewrite.yml` | **No change** | Already has a daily `schedule` + `workflow_dispatch`. |
| `history-rewrite-tests.yml` | **Added `pull_request`/`push` (path-scoped) + `workflow_dispatch`, fixed the `if:` gate** | The only file with **zero** fallback of any kind. Job is self-contained (bats/shellcheck), no real dependency on Docker Build's output. |
| `security-pr.yml` | **No change** | Already has 4 independent trigger types — the template for "already hardened." |
| `supply-chain-verify.yml` | **No change** | Already has `schedule` (weekly) + `release`, independent of `workflow_run`. |
| `docker-build.yml` | **No change** (comment only) | Its real triggers (`push`/`pull_request`) never route through `workflow_run` — categorically unaffected. The `workflow_run`-on-"Docker Lint" link is dormant (`docker-lint.yml` is `workflow_dispatch`-only). |

## Other default-branch-sensitive assumptions

Searched for `default_branch`/`github.event.repository.default_branch` references across `.github/`, `docs/`, `scripts/`. One hit in an **archived** plan doc (not live code). One adjacent heuristic in `scripts/local-patch-report.sh` (prefers `origin/development` as baseline) — evaluated against CLAUDE.md's git-flow convention and confirmed **not stale**: it describes the team's branching convention (`development` = day-to-day integration branch, `main` = release target), which is unaffected by the GitHub API `default_branch` setting. No other findings.

## Why this PR targets `main`, not `development`

`propagate-changes.yml` only ever propagates `main → development`, never the reverse. `main` and `development` have already drifted in exactly the way a silently-failing `propagate-changes.yml` would cause: `.github/workflows/auto-versioning.yml` and `auto-changelog.yml` were deleted from `main` when `release-please.yml` replaced them, but never propagated to `development`. Landing this PR on `main` means its merge triggers Docker Build on `main` → triggers `propagate-changes.yml`'s normal sync PR → merging that PR cleans up the stale files via an ordinary 3-way merge, while also being the first real end-to-end validation that the default-branch fix restores the propagate chain.

## Test plan
- [x] `actionlint` clean on all 4 touched files
- [x] `lefthook run pre-commit` clean on every commit
- [x] Manually confirmed `docs.yml`'s `deploy` job gate (already `main`-only) is untouched
- [x] Manually confirmed `history-rewrite-tests.yml`'s existing `concurrency.group` (already `event_name`-keyed) needs no further change
- [x] No `backend/`, `frontend/`, `docs/features.md`, or `ARCHITECTURE.md` files touched — diff confined to `.github/workflows/*.yml`