### PR TITLE
fix(ci): tune apt timeouts to fail fast on stalled CI mirror connections

### DIFF
--- a/.github/workflows/e2e-tests-split.yml
+++ b/.github/workflows/e2e-tests-split.yml
@@ -323,6 +323,14 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Harden apt for flaky CI mirrors
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-charon-ci-reliability > /dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          APTCONF
+
       - name: Install Playwright Chromium
         run: |
           set -uo pipefail
@@ -564,6 +572,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      - name: Harden apt for flaky CI mirrors
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-charon-ci-reliability > /dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          APTCONF
 
       - name: Install Playwright Chromium (required by security-tests dependency)
         run: |
@@ -824,6 +840,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      - name: Harden apt for flaky CI mirrors
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-charon-ci-reliability > /dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          APTCONF
 
       - name: Install Playwright Chromium (required by security-tests dependency)
         run: |
@@ -1112,6 +1136,14 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Harden apt for flaky CI mirrors
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-charon-ci-reliability > /dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          APTCONF
+
       - name: Install Playwright Chromium
         run: |
           set -uo pipefail
@@ -1356,6 +1388,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      - name: Harden apt for flaky CI mirrors
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-charon-ci-reliability > /dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          APTCONF
 
       - name: Install Playwright Chromium (required by security-tests dependency)
         run: |
@@ -1616,6 +1656,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      - name: Harden apt for flaky CI mirrors
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-charon-ci-reliability > /dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          APTCONF
 
       - name: Install Playwright Chromium (required by security-tests dependency)
         run: |


### PR DESCRIPTION
## Summary

The bash `timeout`/retry loop wrapping `npx playwright install --with-deps` (added in #1259 to stop apt hangs from burning the job's full 60-minute timeout) still lost all 3 retry attempts to the same degraded connection in a recent run ([job](https://github.com/Wikid82/Charon/actions/runs/32250584432/job/96063543650)):

```
12:14:24  Get:2 ... fonts-ipafont-gothic ... [3513 kB]
12:19:31  Get:3 ... fonts-freefont-ttf ... [5641 kB]   ← 5+ min for the next package to even start
12:24:16  timeout fires (10 min elapsed)
```

apt wasn't erroring or fully stalled with zero progress (the original bug #1259 fixed) — it was crawling at near-zero throughput on `azure.archive.ubuntu.com`. Since our outer retry loop doesn't change which connection/mirror apt uses, all 3 attempts hit the same degraded path and all 3 timed out, with no actual retry benefit.

## Fix

Write an `apt.conf.d` drop-in before the first browser install in each of the 6 E2E jobs, setting:
```
Acquire::Retries "3";
Acquire::http::Timeout "15";
Acquire::https::Timeout "15";
```

This makes apt itself detect and abandon a stalled connection within 15s and retry against a fresh one, instead of sitting on one bad connection for the whole 10-minute outer budget — so the existing 3-attempt outer loop actually gets a chance to succeed against a different connection, rather than exhausting all 3 attempts on the same degraded path.

## Test plan
- [x] `actionlint` clean (including shellcheck validation of the embedded heredoc)
- [x] Confirmed the YAML block-scalar indentation produces a correctly-terminated heredoc (parsed the actual script content via PyYAML to verify)
- [x] `lefthook run pre-commit` clean