### PR TITLE
fix(ci): clean up orphaned apt/dpkg processes between Playwright install retries

### DIFF
--- a/.github/workflows/e2e-tests-split.yml
+++ b/.github/workflows/e2e-tests-split.yml
@@ -339,6 +339,10 @@ jobs:
             timeout 10m npx playwright install --with-deps chromium && break
             if [ "$attempt" -lt 3 ]; then
               echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              echo "Cleaning up any orphaned apt/dpkg processes and stale locks..." >&2
+              sudo pkill -9 -f '(^|/)(apt|apt-get|dpkg)( |$)' 2>/dev/null || true
+              sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+              sudo dpkg --configure -a > /dev/null 2>&1 || true
               sleep 15
             else
               echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
@@ -589,6 +593,10 @@ jobs:
             timeout 10m npx playwright install --with-deps chromium && break
             if [ "$attempt" -lt 3 ]; then
               echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              echo "Cleaning up any orphaned apt/dpkg processes and stale locks..." >&2
+              sudo pkill -9 -f '(^|/)(apt|apt-get|dpkg)( |$)' 2>/dev/null || true
+              sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+              sudo dpkg --configure -a > /dev/null 2>&1 || true
               sleep 15
             else
               echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
@@ -604,6 +612,10 @@ jobs:
             timeout 10m npx playwright install --with-deps firefox && break
             if [ "$attempt" -lt 3 ]; then
               echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              echo "Cleaning up any orphaned apt/dpkg processes and stale locks..." >&2
+              sudo pkill -9 -f '(^|/)(apt|apt-get|dpkg)( |$)' 2>/dev/null || true
+              sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+              sudo dpkg --configure -a > /dev/null 2>&1 || true
               sleep 15
             else
               echo "ERROR: Playwright firefox install failed after 3 attempts" >&2
@@ -857,6 +869,10 @@ jobs:
             timeout 10m npx playwright install --with-deps chromium && break
             if [ "$attempt" -lt 3 ]; then
               echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              echo "Cleaning up any orphaned apt/dpkg processes and stale locks..." >&2
+              sudo pkill -9 -f '(^|/)(apt|apt-get|dpkg)( |$)' 2>/dev/null || true
+              sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+              sudo dpkg --configure -a > /dev/null 2>&1 || true
               sleep 15
             else
               echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
@@ -872,6 +888,10 @@ jobs:
             timeout 10m npx playwright install --with-deps webkit && break
             if [ "$attempt" -lt 3 ]; then
               echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              echo "Cleaning up any orphaned apt/dpkg processes and stale locks..." >&2
+              sudo pkill -9 -f '(^|/)(apt|apt-get|dpkg)( |$)' 2>/dev/null || true
+              sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+              sudo dpkg --configure -a > /dev/null 2>&1 || true
               sleep 15
             else
               echo "ERROR: Playwright webkit install failed after 3 attempts" >&2
@@ -1152,6 +1172,10 @@ jobs:
             timeout 10m npx playwright install --with-deps chromium && break
             if [ "$attempt" -lt 3 ]; then
               echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              echo "Cleaning up any orphaned apt/dpkg processes and stale locks..." >&2
+              sudo pkill -9 -f '(^|/)(apt|apt-get|dpkg)( |$)' 2>/dev/null || true
+              sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+              sudo dpkg --configure -a > /dev/null 2>&1 || true
               sleep 15
             else
               echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
@@ -1405,6 +1429,10 @@ jobs:
             timeout 10m npx playwright install --with-deps chromium && break
             if [ "$attempt" -lt 3 ]; then
               echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              echo "Cleaning up any orphaned apt/dpkg processes and stale locks..." >&2
+              sudo pkill -9 -f '(^|/)(apt|apt-get|dpkg)( |$)' 2>/dev/null || true
+              sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+              sudo dpkg --configure -a > /dev/null 2>&1 || true
               sleep 15
             else
               echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
@@ -1420,6 +1448,10 @@ jobs:
             timeout 10m npx playwright install --with-deps firefox && break
             if [ "$attempt" -lt 3 ]; then
               echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              echo "Cleaning up any orphaned apt/dpkg processes and stale locks..." >&2
+              sudo pkill -9 -f '(^|/)(apt|apt-get|dpkg)( |$)' 2>/dev/null || true
+              sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+              sudo dpkg --configure -a > /dev/null 2>&1 || true
               sleep 15
             else
               echo "ERROR: Playwright firefox install failed after 3 attempts" >&2
@@ -1673,6 +1705,10 @@ jobs:
             timeout 10m npx playwright install --with-deps chromium && break
             if [ "$attempt" -lt 3 ]; then
               echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              echo "Cleaning up any orphaned apt/dpkg processes and stale locks..." >&2
+              sudo pkill -9 -f '(^|/)(apt|apt-get|dpkg)( |$)' 2>/dev/null || true
+              sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+              sudo dpkg --configure -a > /dev/null 2>&1 || true
               sleep 15
             else
               echo "ERROR: Playwright chromium install failed after 3 attempts" >&2
@@ -1688,6 +1724,10 @@ jobs:
             timeout 10m npx playwright install --with-deps webkit && break
             if [ "$attempt" -lt 3 ]; then
               echo "Attempt ${attempt}/3 failed; retrying in 15s..." >&2
+              echo "Cleaning up any orphaned apt/dpkg processes and stale locks..." >&2
+              sudo pkill -9 -f '(^|/)(apt|apt-get|dpkg)( |$)' 2>/dev/null || true
+              sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+              sudo dpkg --configure -a > /dev/null 2>&1 || true
               sleep 15
             else
               echo "ERROR: Playwright webkit install failed after 3 attempts" >&2


### PR DESCRIPTION
## Summary

PR #1262's re-run surfaced a new bug in the apt-reliability hardening from #1263, on both WebKit shards ([shard 1](https://github.com/Wikid82/Charon/actions/runs/32258530916/job/96090000811), [shard 2](https://github.com/Wikid82/Charon/actions/runs/32258530916/job/96090000687)):

```
Attempt 1: hits the full 10-minute timeout (mirror slowness — not a full stall, #1263's actual target)
Attempt 2: fails in ~17s — E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 3951 (apt-get)
Attempt 3: fails in ~17s — same lock error
```

The outer `timeout 10m` wrapping `npx playwright install --with-deps` kills the top-level node process when it fires, but the underlying `apt-get` runs as root via `sudo` in a separate process tree that `timeout` doesn't reach. When attempt 1 genuinely times out, the orphaned `apt-get` process keeps running in the background holding the dpkg lock — so attempt 2 fails immediately on the lock, and so does attempt 3, burning all remaining retries in seconds with zero chance of success.

This is the same underlying class of bug as the `nick-fields/retry` `EPERM` issue fixed in #1259: killing a process that has escalated privilege via `sudo` doesn't reliably reach its children.

## Fix

Before each retry (all 10 install sites), clean up any lingering apt/apt-get/dpkg processes and clear stale lock files so the next attempt starts clean instead of immediately failing on a lock held by the previous attempt's orphan:
```bash
sudo pkill -9 -f '(^|/)(apt|apt-get|dpkg)( |$)' 2>/dev/null || true
sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
sudo dpkg --configure -a > /dev/null 2>&1 || true
```

## Test plan
- [x] `actionlint` clean (including shellcheck on the embedded script)
- [x] `lefthook run pre-commit` clean
- [x] Confirmed all 10 install-retry sites got the cleanup step