### PR TITLE
chore(ci): scope e2e-tests-split.yml's pull_request trigger to relevant paths

### DIFF
--- a/.github/workflows/e2e-tests-split.yml
+++ b/.github/workflows/e2e-tests-split.yml
@@ -80,6 +80,26 @@ on:
         default: false
         type: boolean
   pull_request:
+    # Only run this ~15-job, 20-30 minute E2E matrix for changes that can
+    # actually affect it. Everything else (CI-only workflow tweaks in other
+    # files, docs, release-please's version-bump-only PRs, skills/templates)
+    # skips it entirely. push/workflow_run/workflow_dispatch triggers above
+    # are deliberately left unfiltered -- see docker-build.yml/orthrus-build.yml
+    # for the same paths-on-pull_request-only convention already used in
+    # this repo.
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'tests/**'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.docker/compose/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'playwright.config.js'
+      - 'go.work'
+      - 'go.work.sum'
+      - '.github/workflows/e2e-tests-split.yml'
 
 env:
   NODE_VERSION: '24.19.0'


### PR DESCRIPTION
## Summary

`e2e-tests-split.yml`'s `pull_request:` trigger had no path filter, so the full ~15-job, 20-30 minute E2E matrix ran on every PR regardless of what changed — including PRs that touched only unrelated CI workflow files, docs, or release-please's version-bump-only PRs (which touch exactly one file: `.release-please-manifest.json`). None of those can affect E2E test outcomes.

## Fix

Added `paths:` to the `pull_request:` trigger, scoped to what the E2E suite actually builds/tests against:
- `backend/**`, `frontend/**` — built into the Docker image under test
- `tests/**` — the Playwright suite itself
- `Dockerfile`, `.dockerignore` — the image build
- `.docker/compose/**` — the E2E compose stack (`docker-compose.playwright-ci.yml`)
- `package.json`, `package-lock.json`, `playwright.config.js` — root-level npm/Playwright config (confirmed these live at repo root, not under `tests/`)
- `go.work`, `go.work.sum` — the Go workspace file backend/agent both depend on
- `.github/workflows/e2e-tests-split.yml` — the workflow itself

Matches the existing `paths:`-on-`pull_request`-only convention already used in this repo (`docker-build.yml`, `orthrus-build.yml`) — the `push`/`workflow_run`/`workflow_dispatch` triggers are deliberately left unfiltered, same as that precedent. This only reduces PR-iteration noise; post-merge validation coverage (nightly, weekly promotion) is unaffected.

Targets `development` (not `main`) since this is a quality-of-life CI change, not a hotfix — normal flow, soaks via nightly before the next promotion.

## Test plan
- [x] `actionlint` clean
- [x] `lefthook run pre-commit` clean
- [x] Manually traced every file `e2e-tests-split.yml` builds/runs against (grepped for `Dockerfile`/`docker-compose` references, checked `Dockerfile`'s `COPY` sources, confirmed `package.json`/`playwright.config.js` live at repo root) to make sure the allowlist doesn't miss anything that could silently skip real E2E coverage
- [x] Confirmed release-please's own release PR (#1264) touches only `.release-please-manifest.json`, which is correctly excluded