### PR TITLE
fix(ci): restore toolchain pin on main + guard sync-pin-on-pr against protected branches

### DIFF
--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -314,10 +314,26 @@ jobs:
     # commit when the Dockerfile pin genuinely changes. With the deterministic
     # build above (same key => same digest) this essentially never fires unless a
     # tracked pin actually moved on the PR.
+    #
+    # Hard guards (2026-09-08 incident): this job pushes to
+    # `github.event.pull_request.head.ref`, so it must NEVER run when that head
+    # is a long-lived branch. The main -> development auto-propagation PR (#1307)
+    # has head ref `main`; its merge ref pulls development's gRPC bump into the
+    # key computation, and the resulting pin got committed straight to `main`.
+    # `github.actor` was not the bot on that event (propagation runs under a
+    # human/PAT identity), so the actor guard alone did not catch it — also
+    # check the PR author, and refuse any protected head ref outright. A genuine
+    # key move on `development` is handled by `open-bump-pr` (a reviewed bot PR),
+    # not by this in-place sync.
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'github-actions[bot]' &&
+      github.event.pull_request.user.login != 'github-actions[bot]' &&
+      github.event.pull_request.head.ref != 'main' &&
+      github.event.pull_request.head.ref != 'development' &&
+      github.event.pull_request.head.ref != 'nightly' &&
+      github.event.pull_request.head.ref != 'feature/beta-release' &&
       needs.build-toolchain.outputs.digest != ''
     runs-on: ubuntu-latest
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ARG CHARON_TOOLCHAIN_IMAGE=ghcr.io/wikid82/charon-toolchain
 # NOT Renovate-tracked (a content-hash tag has no series to follow, N7) — the
 # toolchain-image.yml bot owns these two lines. DIGEST is the arch-independent
 # manifest-list (OCI index) digest, so one pin covers linux/amd64 + linux/arm64.
-ARG CHARON_TOOLCHAIN_TAG=caddy-crowdsec-9eb9862f44b9e769
-ARG CHARON_TOOLCHAIN_DIGEST=sha256:b41e571d5951bbfc3daa3dccdca033ad9dee535a8e720ac7e3b0bce338f223b2
+ARG CHARON_TOOLCHAIN_TAG=caddy-crowdsec-1efe7f19fa52a512
+ARG CHARON_TOOLCHAIN_DIGEST=sha256:6575f4c6a9f76074870c64df9dd4c9ebee812342f37f52ae5ef8f511ba9f8f00
 
 # Stage selector — default consumes the prebuilt toolchain image (no compile).
 # Fork PRs / bootstrap / offline builds pass


### PR DESCRIPTION
## Unblocks `main` — `verify-toolchain-pin` is currently red on every PR

### Fix 1 (commit 1): restore the toolchain pin

`6f38be5c` ("chore(docker): sync toolchain image pin to
caddy-crowdsec-9eb9862f44b9e769"), authored by `github-actions[bot]` at
07:51 UTC, was pushed **directly to `main`**. It is `toolchain-image.yml`'s
`sync-pin-on-pr` job running on the bot-authored `main -> development`
auto-propagation PR **#1307**: that job checks out
`github.event.pull_request.head.ref` — which for a propagation PR **is `main`** —
recomputes the toolchain key against the merge ref (which pulls in
`development`'s `c32e611a` gRPC 1.83.2 bump, a toolchain-key input) and commits
the two-line pin bump onto the head branch.

`main`'s actual recipe still has `GRPC_VERSION=1.83.1`, whose key is
`caddy-crowdsec-1efe7f19fa52a512`. The pin now on `main` points at the
gRPC-1.83.2 key, so `scripts/verify-toolchain-pin.sh` fails everywhere.

This commit reverts `6f38be5c` exactly (two `ARG` lines), restoring:

| ARG | value |
| --- | --- |
| `CHARON_TOOLCHAIN_TAG` | `caddy-crowdsec-1efe7f19fa52a512` |
| `CHARON_TOOLCHAIN_DIGEST` | `sha256:6575f4c6a9f76074870c64df9dd4c9ebee812342f37f52ae5ef8f511ba9f8f00` |

This is the pair set at `c0ee1195`, CI-green at `e3b76d04`, and the digest
`#1300`'s `docker-build` actually pulled
(`#17 [toolchain-prebuilt] FROM …@sha256:6575f4c6…`).

**Verified on this branch:**
- `bash scripts/toolchain-key.sh` → `caddy-crowdsec-1efe7f19fa52a512` (matches restored TAG)
- `docker buildx imagetools inspect ghcr.io/wikid82/charon-toolchain:caddy-crowdsec-1efe7f19fa52a512` → `sha256:6575f4c6a9f76074870c64df9dd4c9ebee812342f37f52ae5ef8f511ba9f8f00` (matches restored DIGEST)

### Fix 2 (commit 2): stop `sync-pin-on-pr` from ever pushing to a long-lived branch

The job's only guard was `github.actor != 'github-actions[bot]'`, which did
**not** fire here — the propagation PR's `pull_request` event runs under a
non-bot actor even though the PR is bot-authored with head ref `main`. Added to
the job `if:`:

- refuse any protected head ref outright — `main` / `development` / `nightly` /
  `feature/beta-release` (this job has no business rewriting a long-lived branch
  in place);
- also skip when the PR **author** is `github-actions[bot]`
  (`github.event.pull_request.user.login`), not just the triggering actor;
- existing actor guard retained.

Legitimate toolchain-key moves on `development` remain handled by the
`open-bump-pr` job (a reviewed bot PR), which is unchanged.

No in-tree harness asserts on workflow `if:` guards (bats covers the scripts,
not the YAML); `actionlint` passes. A `yq`-based assertion could be added later.

## Relationship to other in-flight PRs

- `#1306` (integration-test consolidation) already squash-merged to `main` as `255a23df` — unaffected by this.
- `#1308` (integration image artifact retention `1d → 3d`) is a separate tiny follow-up, also based on `main`; it will go green once this PR lands and it is rebased.

