### PR TITLE
chore(docker): sync toolchain pin to development's gRPC 1.83.2 recipe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ARG CHARON_TOOLCHAIN_IMAGE=ghcr.io/wikid82/charon-toolchain
 # NOT Renovate-tracked (a content-hash tag has no series to follow, N7) — the
 # toolchain-image.yml bot owns these two lines. DIGEST is the arch-independent
 # manifest-list (OCI index) digest, so one pin covers linux/amd64 + linux/arm64.
-ARG CHARON_TOOLCHAIN_TAG=caddy-crowdsec-1efe7f19fa52a512
-ARG CHARON_TOOLCHAIN_DIGEST=sha256:6575f4c6a9f76074870c64df9dd4c9ebee812342f37f52ae5ef8f511ba9f8f00
+ARG CHARON_TOOLCHAIN_TAG=caddy-crowdsec-9eb9862f44b9e769
+ARG CHARON_TOOLCHAIN_DIGEST=sha256:b41e571d5951bbfc3daa3dccdca033ad9dee535a8e720ac7e3b0bce338f223b2
 
 # Stage selector — default consumes the prebuilt toolchain image (no compile).
 # Fork PRs / bootstrap / offline builds pass


### PR DESCRIPTION
## What

Bumps the two toolchain-pin `ARG` lines in `Dockerfile` on `development`:

| ARG | from (propagated by #1307) | to |
| --- | --- | --- |
| `CHARON_TOOLCHAIN_TAG` | `caddy-crowdsec-1efe7f19fa52a512` | `caddy-crowdsec-9eb9862f44b9e769` |
| `CHARON_TOOLCHAIN_DIGEST` | `sha256:6575f4c6…f8f00` | `sha256:b41e571d5951bbfc3daa3dccdca033ad9dee535a8e720ac7e3b0bce338f223b2` |

## Why

`development` carries `c32e611a` (gRPC 1.83.2) — a toolchain-key input that
`main` does not have yet. The pin that propagation PR #1307 brought from `main`
was computed for `main`'s gRPC-1.83.1 recipe (`…1efe7f19…`). On `development`'s
recipe the key recomputes to `…9eb9862f…`, so `verify-toolchain-pin` is red on
`development` until the pin is synced.

This is the manual equivalent of the daily `open-bump-pr` bot (now using the
`chore(docker):` convention, per the change in #1308). **Supersedes bot PR
#1310**, which is being closed.

## Verification (on this branch)

- `bash scripts/toolchain-key.sh` → `caddy-crowdsec-9eb9862f44b9e769` ✅
- `docker buildx imagetools inspect ghcr.io/wikid82/charon-toolchain:caddy-crowdsec-9eb9862f44b9e769` → `sha256:b41e571d5951bbfc3daa3dccdca033ad9dee535a8e720ac7e3b0bce338f223b2` ✅

Base `development`. Do not merge before CI is green.

