### PR TITLE
ci: pin regctl release + widen toolchain freshness-guard bats coverage (#1304)

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -109,6 +109,11 @@ jobs:
 
       - name: Install regctl
         uses: iarekylew00t/regctl-installer@c2202c17a65fe59371c71ecc169c9e58c3710a15 # v4.0.16
+        with:
+          # Pin the regctl binary to an explicit released version (not the
+          # action's `latest` default) so this required check is reproducible
+          # and can't shift underneath us when a new regctl ships.
+          regctl-release: v0.11.6
 
       - name: Verify the pinned toolchain image matches the recipe
         env:

--- a/scripts/tests/helpers/toolchain_fixture.bash
+++ b/scripts/tests/helpers/toolchain_fixture.bash
@@ -44,11 +44,13 @@ tf_write_dockerfile() {
   local geoip2_version="${TF_GEOIP2_VERSION:-v0.0.0-20260623062220-3675c6e7e63d}"
   local caddy_get_line="${TF_CADDY_GET_LINE:-    _retry go get golang.org/x/net@v0.58.0; \\}"
   local golang_digest="${TF_GOLANG_DIGEST:-sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125}"
+  local alpine_image="${TF_ALPINE_IMAGE:-alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b}"
+  local xx_pin="${TF_XX_PIN:-tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707}"
 
   cat > "$TF_DF" <<EOF
 # syntax=docker/dockerfile:1
 ARG GO_VERSION=1.27.1
-ARG ALPINE_IMAGE=alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+ARG ALPINE_IMAGE=${alpine_image}
 ARG CROWDSEC_VERSION=1.8.1
 ARG EXPR_LANG_VERSION=1.17.8
 ARG XNET_VERSION=0.58.0
@@ -69,7 +71,7 @@ ARG CHARON_TOOLCHAIN_IMAGE=ghcr.io/wikid82/charon-toolchain
 ARG CHARON_TOOLCHAIN_TAG=caddy-crowdsec-0000000000000000
 ARG CHARON_TOOLCHAIN_DIGEST=sha256:0000000000000000000000000000000000000000000000000000000000000000
 
-FROM --platform=\$BUILDPLATFORM tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx
+FROM --platform=\$BUILDPLATFORM ${xx_pin} AS xx
 
 # renovate: datasource=docker depName=golang
 FROM --platform=\$BUILDPLATFORM golang:\${GO_VERSION}-alpine@${golang_digest} AS caddy-inline
@@ -143,6 +145,21 @@ tf_stub_regctl() {
 case "\$1 \$2" in
   "registry login") exit 0 ;;
   "image digest")   printf '%s\n' "${digest}"; exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$TF_BIN/regctl"
+}
+
+# Install a fake `regctl` on PATH whose `image digest` call FAILS (non-zero,
+# no stdout) — simulates the pinned `:$KEY` tag not resolving in the registry.
+# `registry login` still succeeds so the script reaches the digest lookup.
+tf_stub_regctl_unresolvable() {
+  cat > "$TF_BIN/regctl" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "registry login") exit 0 ;;
+  "image digest")   echo "regctl: manifest unknown" >&2; exit 1 ;;
   *) exit 0 ;;
 esac
 EOF

--- a/scripts/tests/toolchain-key.bats
+++ b/scripts/tests/toolchain-key.bats
@@ -6,6 +6,8 @@
 #   * changes when a `go get` line INSIDE caddy-inline changes
 #   * changes when a tracked ARG default (CADDY_VERSION / CADDY_GEOIP2_VERSION) moves
 #   * changes when the digest-pinned golang base moves
+#   * changes when the tonistiigi/xx pin moves
+#   * changes when the ALPINE_IMAGE pin moves
 #   * changes when .trivyignore changes
 #   * fails loudly if stage extraction breaks
 
@@ -68,6 +70,32 @@ key_of() { bash "$TF_ROOT/scripts/toolchain-key.sh" "$TF_DF"; }
   tf_write_dockerfile
   after="$(key_of)"
   [ "$before" != "$after" ]
+}
+
+@test "changes when the tonistiigi/xx pin moves (N4)" {
+  before="$(key_of)"
+  export TF_XX_PIN='tonistiigi/xx:1.9.1@sha256:1111111111111111111111111111111111111111111111111111111111111111'
+  tf_write_dockerfile
+  after="$(key_of)"
+  [ "$before" != "$after" ]
+}
+
+@test "changes when the ALPINE_IMAGE pin moves" {
+  before="$(key_of)"
+  export TF_ALPINE_IMAGE='alpine:3.25.0@sha256:2222222222222222222222222222222222222222222222222222222222222222'
+  tf_write_dockerfile
+  after="$(key_of)"
+  [ "$before" != "$after" ]
+}
+
+@test "stable when the tonistiigi/xx and ALPINE_IMAGE pins are re-emitted unchanged" {
+  before="$(key_of)"
+  # Re-write the fixture with the exact same (default) xx / alpine pins.
+  export TF_XX_PIN='tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707'
+  export TF_ALPINE_IMAGE='alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b'
+  tf_write_dockerfile
+  after="$(key_of)"
+  [ "$before" = "$after" ]
 }
 
 @test "changes when .trivyignore changes" {

--- a/scripts/tests/verify-toolchain-pin.bats
+++ b/scripts/tests/verify-toolchain-pin.bats
@@ -6,6 +6,8 @@
 #   mismatched tag                               -> exit 1 (actionable)
 #   same-repo + regctl absent                    -> exit 1
 #   same-repo + GHCR_READ_TOKEN unset            -> exit 1
+#   same-repo + :$KEY tag does not resolve       -> exit 1
+#   same-repo + CHARON_TOOLCHAIN_DIGEST empty    -> exit 1
 #   same-repo + GHCR digest != pinned digest     -> exit 1
 #   same-repo + GHCR digest == pinned digest     -> exit 0
 
@@ -72,6 +74,40 @@ verify() { bash "$TF_ROOT/scripts/verify-toolchain-pin.sh" "$TF_DF"; }
   run verify
   [ "$status" -eq 1 ]
   [[ "$output" == *"hand-edited or stale"* ]]
+}
+
+@test "same-repo PR + pinned :\$KEY tag does not resolve in GHCR: exit 1 (failure-closed)" {
+  tf_stub_regctl_unresolvable
+  export GITHUB_EVENT_NAME=pull_request
+  export GITHUB_REPOSITORY=wikid82/Charon
+  export GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME=wikid82/Charon
+  export GHCR_READ_TOKEN=tok
+  run verify
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"does not resolve in GHCR"* ]]
+}
+
+@test "same-repo PR + CHARON_TOOLCHAIN_DIGEST value blank: exit 1 (failure-closed)" {
+  tf_stub_regctl "$GOOD_DIGEST"
+  sed -i "s|^ARG CHARON_TOOLCHAIN_DIGEST=.*|ARG CHARON_TOOLCHAIN_DIGEST=|" "$TF_DF"
+  export GITHUB_EVENT_NAME=pull_request
+  export GITHUB_REPOSITORY=wikid82/Charon
+  export GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME=wikid82/Charon
+  export GHCR_READ_TOKEN=tok
+  run verify
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"CHARON_TOOLCHAIN_DIGEST not found"* ]]
+}
+
+@test "same-repo PR + CHARON_TOOLCHAIN_DIGEST ARG line absent: exit 1 (failure-closed)" {
+  tf_stub_regctl "$GOOD_DIGEST"
+  sed -i "/^ARG CHARON_TOOLCHAIN_DIGEST=/d" "$TF_DF"
+  export GITHUB_EVENT_NAME=push
+  export GITHUB_REPOSITORY=wikid82/Charon
+  export GHCR_READ_TOKEN=tok
+  run verify
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"CHARON_TOOLCHAIN_DIGEST not found"* ]]
 }
 
 @test "same-repo PR + GHCR digest matches the pinned digest: exit 0" {

--- a/scripts/verify-toolchain-pin.sh
+++ b/scripts/verify-toolchain-pin.sh
@@ -43,8 +43,8 @@ if [[ ! -f "$df" ]]; then
   exit 2
 fi
 
-arg_value() { # $1 = ARG name
-  grep -E "^ARG $1=" "$df" | head -n1 | cut -d= -f2-
+arg_value() { # $1 = ARG name; empty output (never a hard error) when absent
+  { grep -E "^ARG $1=" "$df" || true; } | head -n1 | cut -d= -f2-
 }
 
 KEY="$("$here/toolchain-key.sh" "$df")"


### PR DESCRIPTION
Small non-blocking follow-ups from the prebuilt-toolchain-image work (#1300), tracked in #1304.

## Item A — pin the `regctl` release version
`.github/workflows/quality-checks.yml` `verify-toolchain-pin` job installed `regctl` via `iarekylew00t/regctl-installer` with the action's default `regctl-release: latest`, so a new `regctl` release could shift this required check's behavior with no repo change. Now pinned to `regctl-release: v0.11.6` (current stable, released 2026-09-02) with a comment explaining why.

## Item B — widen the freshness-guard bats matrix
`scripts/tests/verify-toolchain-pin.bats`:
- same-repo run where the pinned `:$KEY` tag does **not** resolve in the registry -> hard `exit 1` (failure-closed). New `tf_stub_regctl_unresolvable` helper mock (`image digest` exits non-zero), reusing the existing PATH-stub pattern.
- `CHARON_TOOLCHAIN_DIGEST` blank value **and** `ARG` line absent -> hard `exit 1`.

`scripts/tests/toolchain-key.bats`:
- per-input sensitivity for the `FROM tonistiigi/xx:...` pin and `ARG ALPINE_IMAGE` — changing either flips the recomputed key; an unchanged re-emit keeps it stable. New `TF_XX_PIN` / `TF_ALPINE_IMAGE` fixture knobs.

Also hardened `verify-toolchain-pin.sh` `arg_value()`: a missing `ARG` line now yields empty output instead of aborting the script under `set -e` before the actionable `CHARON_TOOLCHAIN_DIGEST not found` error can print.

`bats scripts/tests/` — 27/27 green. `shellcheck --severity=error` clean on all changed `.sh`/`.bash`. `lefthook run pre-commit` clean.

## Not in scope
`make build-offline` CI coverage and the `caddy-geoip2` pin (no upstream tag yet) remain parked in #1304.
