### PR TITLE
ci: add offline (inline-toolchain) build canary workflow (#1304)

### DIFF
--- a/.github/workflows/build-offline.yml
+++ b/.github/workflows/build-offline.yml
@@ -1,0 +1,81 @@
+# Offline (inline-toolchain) build canary.
+#
+# The default app image build (docker-build.yml / nightly-build.yml) pulls the
+# prebuilt `ghcr.io/wikid82/charon-toolchain` image and `COPY --from`s the custom
+# Caddy + CrowdSec binaries out of it. This workflow exercises the OTHER path:
+# `CADDY_BUILDER_SRC=caddy-inline` / `CROWDSEC_BUILDER_SRC=crowdsec-inline`, which
+# compiles both binaries from source inside the app Dockerfile. That path is what
+# a fork PR, an air-gapped operator, or anyone not logged in to GHCR falls back
+# to, and nothing else in CI builds it end to end — so it can rot silently
+# (a broken `go get` pin, a stage rename, a base-image bump) until someone
+# actually tries to build offline.
+#
+# Why amd64-only + advisory (NOT a required check):
+#   * The inline compile is ~14 min on top of the normal build (Makefile notes
+#     this); a full run is ~20 min warm, more cold. Too slow to gate every PR.
+#   * arm64 would run the two Go compiles under QEMU emulation (45-90+ min) for
+#     no extra signal — the recipe is arch-independent in practice.
+#   * It is a canary: a weekly schedule catches upstream drift, and a tight
+#     `paths:` filter re-validates it whenever the inline recipe itself can
+#     change. Failures open a normal red check on matching PRs but do not block
+#     merge (this context is deliberately absent from the branch ruleset).
+
+name: Build (offline / inline toolchain)
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Wednesday 08:00 UTC — a low-traffic slot clear of toolchain-image.yml
+    # (daily 06:00), security-weekly-rebuild.yml (Tue 12:00) and the Monday
+    # security/codeql/semgrep cluster.
+    - cron: '0 8 * * 3'
+  pull_request:
+    paths:
+      # Keep this minimal: only files that can change what the caddy-inline /
+      # crowdsec-inline stages actually build. Those stages take no repo build
+      # context (only `COPY --from=xx`), so the recipe lives entirely in the
+      # Dockerfile plus the build-context shape (.dockerignore).
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'Makefile'
+      - '.github/workflows/build-offline.yml'
+
+concurrency:
+  group: build-offline-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-offline:
+    name: Build offline image (amd64, from-source Caddy + CrowdSec)
+    runs-on: ubuntu-latest
+    # ~14 min inline compile + normal build; generous headroom for a cold cache.
+    timeout-minutes: 35
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Build charon:offline (inline toolchain path)
+        run: |
+          set -euo pipefail
+          make build-offline \
+            DOCKER_BUILD="docker buildx build" \
+            BUILD_OFFLINE_ARGS="--platform linux/amd64 --load --pull --cache-from type=gha,scope=build-offline --cache-to type=gha,mode=max,scope=build-offline"
+
+      - name: Smoke-check the from-source binaries landed in the image
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint sh charon:offline -c '
+            set -e
+            test -x /usr/bin/caddy
+            test -x /usr/local/bin/crowdsec
+            test -x /usr/local/bin/cscli
+            test -x /app/charon
+            # Functional check on the from-source Caddy (safe, no server start).
+            /usr/bin/caddy version
+          '

--- a/Makefile
+++ b/Makefile
@@ -108,10 +108,19 @@ docker-build-versioned:
 # Build the image WITHOUT pulling the prebuilt toolchain image — compiles the
 # custom Caddy + CrowdSec binaries from source (caddy-inline / crowdsec-inline).
 # Use offline / air-gapped, or when not logged in to GHCR. Slow (~14 min extra).
+#
+# The two --build-arg selectors below are the single source of truth for "build
+# the inline path". Overridable knobs (used by .github/workflows/build-offline.yml):
+#   DOCKER_BUILD        - builder command (default "docker build"; CI passes
+#                         "docker buildx build" for GHA layer caching)
+#   BUILD_OFFLINE_ARGS  - extra flags (e.g. --platform, --load, --cache-from/to)
+DOCKER_BUILD ?= docker build
+BUILD_OFFLINE_ARGS ?=
 build-offline:
-	docker build \
+	$(DOCKER_BUILD) \
 		--build-arg CADDY_BUILDER_SRC=caddy-inline \
 		--build-arg CROWDSEC_BUILDER_SRC=crowdsec-inline \
+		$(BUILD_OFFLINE_ARGS) \
 		-t charon:offline \
 		.
 

--- a/docs/ci/toolchain-image.md
+++ b/docs/ci/toolchain-image.md
@@ -19,6 +19,7 @@ every CI image build.
 | `scripts/lib/dockerfile-stage.sh` | Shared `extract_stage` used by both scripts. |
 | `.github/workflows/toolchain-image.yml` | Builds / publishes / scans. |
 | `.github/workflows/security-weekly-rebuild.yml` | `workflow_call`s the above for the Tuesday full rebuild + MEDIUM/LOW JSON report. |
+| `.github/workflows/build-offline.yml` | Advisory canary (weekly + `Dockerfile`/`Makefile` PR paths, amd64-only). Builds the app image via the `caddy-inline` / `crowdsec-inline` path — i.e. `make build-offline` — so the fork/air-gapped fallback can't rot unnoticed. Not a required check. |
 
 ## Determinism
 


### PR DESCRIPTION
Issue #1304 item 5 — CI coverage for the offline / inline-toolchain build path.

## Problem
The default app image build pulls the prebuilt `charon-toolchain` image and `COPY --from`s the custom Caddy + CrowdSec binaries. The **other** path — `CADDY_BUILDER_SRC=caddy-inline` / `CROWDSEC_BUILDER_SRC=crowdsec-inline`, which compiles both from source — is the fork / air-gapped / not-logged-in-to-GHCR fallback, and nothing in CI builds it end to end. It can rot silently (a broken `go get` pin, a stage rename, a base-image bump) until someone actually tries to build offline.

## New workflow `.github/workflows/build-offline.yml`
- **Advisory, NOT a required check.** The branch ruleset is untouched; this context is deliberately not in the 17. It shows as a normal check on matching PRs.
- **amd64-only**, `timeout-minutes: 35`, `permissions: contents: read` only (the inline path pulls nothing from GHCR — that's the point; no login, no push, no multi-arch).
- **Triggers:** `workflow_dispatch`; `schedule` weekly `0 8 * * 3` (Wed 08:00 UTC — clear of `toolchain-image.yml` daily 06:00, `security-weekly-rebuild.yml` Tue 12:00, and the Monday codeql/semgrep/supply-chain cluster); `pull_request` with a tight `paths:` filter (`Dockerfile`, `.dockerignore`, `Makefile`, the workflow itself — the inline stages take no repo build context beyond `COPY --from=xx`).
- **Build:** `make build-offline` with `DOCKER_BUILD="docker buildx build"` and `BUILD_OFFLINE_ARGS="--platform linux/amd64 --load --pull --cache-from type=gha,scope=build-offline --cache-to type=gha,mode=max,scope=build-offline"` (distinct cache scope from the main + toolchain builds).
- **Smoke step:** asserts the from-source `caddy` / `crowdsec` / `cscli` / `charon` binaries landed in the final image and `caddy version` runs.

## Makefile
`build-offline` parametrized with overridable `DOCKER_BUILD` / `BUILD_OFFLINE_ARGS` so CI reuses the target — the two builder-src `--build-arg` selectors stay a single source of truth — while adding the buildx `--platform` / `--load` / `--cache` flags. Default local `make build-offline` behavior is unchanged.

## Docs
One row added to the components table in `docs/ci/toolchain-image.md`.

## Validation
`actionlint` + `lefthook run pre-commit` clean. `make -n build-offline` (with and without overrides) expands correctly. This PR adds `.github/workflows/build-offline.yml` and touches `Makefile` / `Dockerfile`-adjacent paths, so its own `pull_request` run exercises the workflow end to end.