### PR TITLE
chore: re-anchor go/log-injection CodeQL suppression after route-group split

### DIFF
--- a/.github/codeql/codeql-suppressions.yml
+++ b/.github/codeql/codeql-suppressions.yml
@@ -48,7 +48,9 @@ suppressions:
 
   - rule_id: go/log-injection
     path: backend/internal/api/handlers/remote_server_handler.go
-    line: 142
+    line_range:
+      start: 146
+      end: 150
     reason: >
       False positive. The logged value is the goroutine's `id uint`
       parameter (bound from `server.ID`, a GORM-assigned numeric primary
@@ -67,6 +69,14 @@ suppressions:
       this entry is the documented fallback for when a local SARIF scan
       does not populate `result.suppressions` (see the
       go/cookie-secure-not-set entry above for the same limitation).
+      Extended 2026-09-09: the management-API authorization hardening
+      (fix(security): apply deny-by-default authorization on management
+      API subroutes) changed RemoteServerHandler.RegisterRoutes to a
+      (read, admin *gin.RouterGroup) split, adding lines above Update and
+      shifting the sink from line 142 to ~148; widened to a line_range so
+      the multi-line `logger.Log().WithError(...).WithField(...).Warn(...)`
+      chain stays covered regardless of which line CodeQL anchors
+      startLine to.
     added: "2026-08-27"
     review_by: "2026-11-27"
 


### PR DESCRIPTION
## Why

The management-API authorization hardening (#1316) changed `RemoteServerHandler.RegisterRoutes` to a `(read, admin *gin.RouterGroup)` split, adding lines above `Update()` and shifting the already-suppressed `logger.Log()...Warn()` `go/log-injection` sink in `remote_server_handler.go` from line 142 to ~148.

`.github/codeql/codeql-suppressions.yml` pinned that entry to an exact `line: 142`, so after the shift the findings-gate no longer matched it and counted the (unchanged, still-false-positive — logging a `uint` primary key) result as **blocking** on the full-tree CodeQL scan that the `main` → `development` propagation PR (#1320) runs. #1316's own CodeQL check passed because PR-scoped analysis is diff-informed and doesn't re-block a pre-existing finding whose suppression drifted.

## Change

Widen the entry to `line_range: {start: 146, end: 150}`, exactly mirroring the sibling `uptime_service.go` entry that hit this same drift before (commit `8466a6eb`), so the multi-line log chain stays covered regardless of which line CodeQL anchors `startLine` to. Reason text keeps a dated `Extended 2026-09-09` note per the file's convention.

**No code or behavior change.** Data-only edit to the CodeQL suppression list. Unblocks #1320.