### PR TITLE
fix(ci): toolchain rebuild bot evaluates development, not the default branch

### DIFF
--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -81,6 +81,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Non-PR entry points (schedule / workflow_dispatch, and the weekly
+          # rebuild's workflow_call — whose github.event_name is the caller's
+          # 'schedule'/'workflow_dispatch') evaluate `development`, not the
+          # default branch (main). `open-bump-pr` opens its digest-bump PR with
+          # `base: development`, and `development` carries its own Dockerfile ARG
+          # bumps (x/net, x/crypto, …) that move the toolchain key independently
+          # of main. Checking out main here made the daily bot blind to
+          # development-side drift, which then only surfaced on the next
+          # main -> development propagation PR's verify-toolchain-pin check.
+          # pull_request keeps the default merge-ref checkout.
+          ref: ${{ github.event_name != 'pull_request' && 'development' || '' }}
 
       - name: Classify trust (same-repo vs fork)
         id: trust
@@ -255,6 +267,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Match build-toolchain: on non-PR triggers, use development's
+          # .trivyignore so the CRITICAL/HIGH gate scores the development-recipe
+          # image against development's suppressions.
+          ref: ${{ github.event_name != 'pull_request' && 'development' || '' }}
 
       - name: Determine scan reference
         id: ref
@@ -389,6 +406,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Evaluate + bump development's Dockerfile pin (this job's PR targets
+          # `base: development`). Never runs on pull_request, so this is always
+          # `development`; the expression mirrors build-toolchain for symmetry.
+          ref: ${{ github.event_name != 'pull_request' && 'development' || '' }}
 
       - name: Decide whether the pin moved
         id: moved


### PR DESCRIPTION
## Problem

The daily `schedule` (and the weekly rebuild's `workflow_call`) runs of `toolchain-image.yml` checked out the **default branch (`main`)**, computed the toolchain key from `main`'s recipe, and compared it to `main`'s Dockerfile pin:

```
cur_tag="$(grep '^ARG CHARON_TOOLCHAIN_TAG=' Dockerfile ...)"   # main's Dockerfile
if [[ "$cur_tag" == "$KEY" ... ]]; then moved=false            # always matches on main -> no PR
```

On `main` the pin is self-consistent, so `open-bump-pr`'s *"did the pin move?"* check was never true and **no bot PR was ever opened** — even though `open-bump-pr` targets `base: development`, and `development` accumulates its own Dockerfile ARG bumps (`x/net`, `x/crypto`, …) that move the toolchain key independently of `main`.

Net effect: **`development`-side toolchain-pin drift had no automated detection or repair path.** It only surfaced when a `main → development` propagation PR ran `verify-toolchain-pin` against the merge recipe (#1320 / #1322) — by which point the pin was already stale on the branch and no bot PR existed to fix it. Today's 06:16 UTC scheduled run executed fine and still opened nothing, for exactly this reason.

## Fix

Pin the `build-toolchain`, `trivy-scan`, and `open-bump-pr` checkouts to `development` on every non-`pull_request` trigger:

```yaml
ref: ${{ github.event_name != 'pull_request' && 'development' || '' }}
```

- `schedule` / `workflow_dispatch` / the weekly `workflow_call` (whose `github.event_name` is the caller's `schedule`) → evaluate + bump **`development`**, matching where `open-bump-pr` already sends its PR.
- `pull_request` → `ref: ''` → default merge-ref checkout, unchanged.
- `sync-pin-on-pr` is untouched — it's PR-only, already checks out the PR head, and stays guarded off for `main`/`development`/`nightly`/`feature/beta-release` head refs (the 2026-09-08 incident guard).

Ternary uses `!= 'pull_request' && 'development' || ''` (not `== ... && '' || ...`) because an empty string is falsy in GitHub Actions expressions and would collapse the ternary.

## Verification

- `actionlint` + `check-yaml` + `semgrep` clean (pre-commit).
- Behaviour is exercised by the next scheduled run / by #1322's own `sync-pin-on-pr` (its head is a normal topic branch, so it self-heals the merge-recipe pin regardless of this change).

Follow-up to the #1320 / #1322 toolchain-freshness investigation.

https://claude.ai/code/session_01Jz4LgwfkxaF8E7TdAgk94y