### PR TITLE
chore(docker): pin caddy-geoip2 to its v1.3 release tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,12 +82,12 @@ ARG CADDY_SECURITY_VERSION=1.1.64
 # renovate: datasource=go depName=github.com/corazawaf/coraza-caddy/v2
 ARG CORAZA_CADDY_VERSION=2.6.1
 # xcaddy plugins that previously resolved "latest" at build time (B4). Pinned so
-# a toolchain-key.sh input moves when the plugin does. caddy-geoip2 publishes NO
-# semver tags, so its pin is the full pseudo-version (leading v included) and the
-# `--with` line interpolates it directly (no added `v`); the renovate marker is
-# kept for discoverability but does not track a pseudo-version (same caveat as N7).
+# a toolchain-key.sh input moves when the plugin does. caddy-geoip2 tags its
+# releases (v1.0-v1.3 as of 2026-06); pinned to the tag so Renovate tracks it.
+# The `--with` line interpolates the value directly (it already carries the
+# leading `v`), unlike the sibling pins that re-add `v` in `--with`.
 # renovate: datasource=go depName=github.com/zhangjiayin/caddy-geoip2
-ARG CADDY_GEOIP2_VERSION=v0.0.0-20260623062220-3675c6e7e63d
+ARG CADDY_GEOIP2_VERSION=v1.3
 # renovate: datasource=go depName=github.com/mholt/caddy-ratelimit
 ARG CADDY_RATELIMIT_VERSION=0.1.0
 ## When an official caddy image tag isn't available on the host, use a


### PR DESCRIPTION
Closes #1329. Last open follow-up from #1304 (toolchain-image work).

## What

`github.com/zhangjiayin/caddy-geoip2` now publishes semver tags (`v1.0`–`v1.3`). Charon's pin `v0.0.0-20260623062220-3675c6e7e63d` already embeds commit `3675c6e7e63d` — which **is** the `v1.3` tag (2026-06-23). Swap the pseudo-version for the tag.

- **Same source commit** → functionally identical bundled Caddy binary.
- Renovate can track the pin again (the `# renovate: datasource=go` marker was inert against a pseudo-version).
- `CADDY_GEOIP2_VERSION` is a `scripts/toolchain-key.sh` input, so the toolchain key moves (`…42331d0f574f9050` → `…00bd5d248b851bdd` locally). `sync-pin-on-pr` will refresh `CHARON_TOOLCHAIN_TAG`/`DIGEST` on this branch and `verify-toolchain-pin` will then pass; the `Build & publish toolchain image` job re-validates the (unchanged) recipe builds on both arches.

## Not switching modules

`porech/caddy-maxmind-geolocation` is a *request matcher*, not a placeholder provider — Charon's geo-blocking builds `{geoip2.country_code} in […]` CEL expressions (`backend/internal/caddy/config.go`), which is `caddy-geoip2`'s API. Upstream is low-activity but alive (last push 2026-06-23, recent data-race/bugfix commits, 0 open issues). Revisit only if it goes dark.

## Local checks

`docker build --check` clean · `dockerfile-check` pass · `semgrep` 0 findings · `toolchain-key.sh` runs.

https://claude.ai/code/session_01Jz4LgwfkxaF8E7TdAgk94y